### PR TITLE
added about menu to main nav

### DIFF
--- a/fec_eregs/templates/regulations/main-header.html
+++ b/fec_eregs/templates/regulations/main-header.html
@@ -55,6 +55,11 @@
             <span class="site-nav__link__title">Legal resources</span>
           </a>
         </li>
+        <li class="site-nav__item" data-submenu="about">
+          <a href="{{ FEC_CMS_URL }}/about" class="site-nav__link">
+            <span class="site-nav__link__title">About</span>
+          </a>
+        </li>
         <li class="site-nav__item utility-nav__item u-under-lg-only">
           <a href="{{ FEC_CMS_URL }}/calendar" class="site-nav__link">Calendar</a>
         </li>

--- a/fec_eregs/templates/regulations/main-header.html
+++ b/fec_eregs/templates/regulations/main-header.html
@@ -55,7 +55,7 @@
             <span class="site-nav__link__title">Legal resources</span>
           </a>
         </li>
-        <li class="site-nav__item" data-submenu="about">
+        <li class="site-nav__item--secondary" data-submenu="about">
           <a href="{{ FEC_CMS_URL }}/about" class="site-nav__link">
             <span class="site-nav__link__title">About</span>
           </a>


### PR DESCRIPTION
This is work to add the About menu to the main navigation of the fec-eregs: 18F/fec-cms#1139

Dependent on fec-style PR here: 18F/fec-style#748