### PR TITLE
Add Snyk vulnerability tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Dependency Status](https://gemnasium.com/badges/github.com/fecgov/fec-eregs.svg)](https://gemnasium.com/github.com/fecgov/fec-eregs)
+[![Dependency Status](https://snyk.io/test/github/fecgov/fec-eregs/badge.svg)](https://snyk.io/test/github/fecgov/fec-eregs)
 
 [![CircleCI](https://circleci.com/gh/fecgov/fec-eregs.svg?style=svg)](https://circleci.com/gh/fecgov/fec-eregs)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Dependency Status](https://snyk.io/test/github/fecgov/fec-eregs/badge.svg)](https://snyk.io/test/github/fecgov/fec-eregs)
+[![Dependency Status](https://gemnasium.com/badges/github.com/fecgov/fec-eregs.svg)](https://gemnasium.com/github.com/fecgov/fec-eregs)
+[![Known Vulnerabilities](https://snyk.io/test/github/fecgov/fec-eregs/badge.svg)](https://snyk.io/test/github/fecgov/fec-eregs)
 
 [![CircleCI](https://circleci.com/gh/fecgov/fec-eregs.svg?style=svg)](https://circleci.com/gh/fecgov/fec-eregs)
 


### PR DESCRIPTION
Add Snyk vulnerability badge: https://snyk.io/docs/badges
We'll use both until we stop using Gemnasium