### PR TITLE
Update `eregs/regulations-site/` package version to 8.4.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ webargs==1.8.1
 pyelasticsearch==1.4
 django-haystack==2.4.1
 psycopg2==2.7.3.2
--e git+https://github.com/18F/regulations-core.git@4.2.0#egg=regcore
+regcore==4.2.0
 
 # regulations-site
 # django, cached-property, six already covered
@@ -19,7 +19,7 @@ requests==2.18.4
 boto3==1.5.13
 celery==4.1.0
 requests-toolbelt==0.8.0
--e git+https://github.com/18F/regulations-site.git@8.4.1#egg=regulations
+regulations==8.4.2
 
 # fec-specific/cloud.gov
 cfenv==0.5.3

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -4,4 +4,4 @@ django-debug-toolbar==1.9.1
 requests[security]
 ipdb==0.10.3
 ipython>=6.0,<7.0
--e git+https://github.com/18F/regulations-parser.git@4.3.1#egg=regulations_parser
+regparser==4.3.1


### PR DESCRIPTION
- New version 8.4.2 now throws 404 errors instead of 500 errors for missing regulations (https://github.com/eregs/regulations-site/pull/515)
- This will address fec-eregs #385: 404 instead of 500 for missing regulations
- Grab packages from `pypi` instead of GitHub

Test with: http://127.0.0.1:8000/116-7/2017-annual-116#116-7 - should throw a 404 on this branch instead of a KeyError on the `develop` branch.

Thank you to @cmc333333 for your help, and getting the new release out so quickly!