### PR TITLE
Add new menus + about menu, implement glossary on eregs

### DIFF
--- a/fec_eregs/static/fec_eregs/js/data/terms.json
+++ b/fec_eregs/static/fec_eregs/js/data/terms.json
@@ -1,0 +1,558 @@
+[
+  {
+    "term": "Act",
+    "definition": "The Federal Election Campaign Act of 1971, as amended (<a href=\"https://www.fec.gov/data/legal/statutes/\">52 U.S.C. §§30101-30146</a>). 11 CFR <a href=\"https://www.fec.gov/regulations/100-18/CURRENT#100-18\">100.18</a>. Prior to September 1, 2014, the Act appeared in Title 2 of the U.S. Code. Sometimes abbreviated FECA."
+  },
+  {
+    "term": "Administrative expense",
+    "definition": "For party committees, rent, utilities, office equipment, office supplies, routine building maintenance and other operating costs not attributable to a specific candidate."
+  },
+  {
+    "term": "Advance",
+    "definition": "The payment by an individual from his or her personal funds, including a personal credit card, for the costs incurred in providing goods or services to, or obtaining goods or services that are used by or on behalf of, a candidate or a political committee.  See <a href=\"https://www.fec.gov/regulations/116-5/CURRENT#116-5\">11 CFR 116.5</a>."
+  },
+  {
+    "term": "Advisory opinion (AO)",
+    "definition": "A formal response from the Commission regarding the legality of a specific activity proposed in an advisory opinion request (AOR). 11 CFR Part <a href=\"https://www.fec.gov/regulations/112\">112</a>."
+  },
+  {
+    "term": "Affiliated committees",
+    "definition": "Committees and organizations that are considered one committee for purposes of the contribution limits. <a href=\"https://www.fec.gov/regulations/110-3/CURRENT#110-3\">11 CFR 110.3(a)(1)</a>. Affiliated committees include (1) All committees established or authorized by a candidate as part of his or her campaign for federal or nonfederal office; and (2) All committees established, financed, maintained or controlled by the same person, group or organization. 11 CFR <a href=\"https://www.fec.gov/regulations/100-5/CURRENT#100-5-g\">100.5(g)(1) and (2)</a>; <a href=\"https://www.fec.gov/regulations/110-3/CURRENT#110-3\">11 CFR 110.3(a)(1)</a>."
+  },
+  {
+    "term": "Agent (of a candidate)",
+    "definition": "An agent of a federal candidate or officeholder is any person who has actual authority, either express or implied, to engage in any of the following activities on behalf of the candidate or officeholder: <ul class='list-bulleted'> <li>To solicit, receive, direct, transfer or spend funds in connection with any election.</li><li>To request or suggest that a communication be created, produced or distributed; </li><li>To make or authorize a communication that meets one or more of the “content standards” for coordination;</li><li>To request or suggest that any other person create, produce, or distribute any communication;</li><li>To be materially involved in decisions regarding the content, intended audience, means, media outlet, timing, frequency, size, prominence or duration of a communication;</li><li>To provide material or information to assist another person in the creation, production or distribution of any communication; or</li>\n<li>To make or direct a communication that is created, produced or distributed with the use of material or information derived from a substantial discussion about the communication with a different candidate;</li></ul> 11 CFR <a href=\"https://www.fec.gov/regulations/109-3/CURRENT#109-3-b\">109.3(b)</a> and <a href=\"https://www.fec.gov/regulations/300-2/CURRENT#300-2-b-3\">300.2(b)(3)</a>."
+  },
+  {
+    "term": "Agent (of a party)",
+    "definition": "An agent is any person who has actual authority, either expressed or implied, to engage in certain activities on behalf of the committee. In the case of state, district and local party committees, these activities are:<ul  class=\"list-bulleted\"><li>Expending or disbursing any funds for federal election activity; </li><li>Transferring or accepting transfers of funds for federal election activity;</li> <li>Engaging in joint fundraising activity if any part of the funds are to be used for federal election activity; or </li><li>Soliciting any funds for, or making or directing any donations to, any tax-exempt 501(c) organization or 527 organization that is not also a political committee, a party committee or an authorized campaign committee. </li>11 CFR <a href=\"https://www.fec.gov/regulations/300-2/CURRENT#300-2-b-2\">300.2(b)(2)</a>.</ul>In the case of the national party committees, these activities are:\n<ul class=\"list-bulleted\"><li>Soliciting, directing or receiving a contribution, donation or transfer of funds; or</li><li>Soliciting any funds for, or making or directing donations to, any tax-exempt 501(c) organization or 527 organization that is not also a political committee, a party committee or an authorized campaign committee.</li> 11 CFR <a href=\"https://www.fec.gov/regulations/300-2/CURRENT#300-2-b-1\">300.2(b)(1)</a>.</ul> In the case of communications, for all party committees, the activities include: <ul class=:\"list-bulleted\"><li>Requesting or suggesting that a communication be created, produced or distributed;</li><li>Creating, producing or distributing any communication at the request of a candidate; or</li><li>Being materially involved in the content or distribution of a communication.</li>11 CFR <a href=\"https://www.fec.gov/regulations/109-3/CURRENT#109-3\">109.3(a)</a>.</ul>"
+  },
+  {
+    "term": "Allocation account",
+    "definition": "A separate federal account into which funds from either a committee’s federal and nonfederal accounts, or (for party committees) from its federal and Levin accounts, are deposited solely to pay expenses that must be allocated. (A party committee must have separate allocation accounts for its federal/nonfederal allocation and for its federal/Levin allocation). 11 CFR <a href=\"https://www.fec.gov/regulations/106-7/CURRENT#106-7\">106.7(f)</a> and <a href=\"https://www.fec.gov/regulations/300-33/CURRENT#300-33-d\">300.33(d)</a>."
+  },
+  {
+    "term": "Authorized committee",
+    "definition": "A political committee that has been authorized by a candidate to accept contributions or make expenditures on his or her behalf, or one that accepts contributions or makes expenditures on behalf of a candidate and has not been disavowed by the candidate."
+  },
+  {
+    "term": "Bundled contribution",
+    "definition": "A contribution forwarded to a reporting committee by a lobbyist/registrant or lobbyist/registrant PAC, or received by a reporting committee and credited to a lobbyist/registrant or lobbyist/registrant PAC. See 11 CFR <a href=\"https://www.fec.gov/regulations/104-22/CURRENT#104-22-a-6\">104.22(a)(6)</a>."
+  },
+  {
+    "term": "Campaign traveler",
+    "definition": "Any candidate traveling in connection with an election for federal office, or any individual traveling in connection with an election for federal office on behalf of a candidate or political committee; or any member of the news media traveling with a candidate. 11 CFR <a href=\"https://www.fec.gov/regulations/100-93/CURRENT#100-93-a-3\">100.93(a)(3)(i)</a>."
+  },
+  {
+    "term": "Candidate",
+    "definition": "An individual seeking nomination for election, or reelection, to a federal office becomes a candidate when he or she (or persons working on his or her behalf) receives contributions or makes expenditures that exceed $5,000."
+  },
+  {
+    "term": "Candidate ID",
+    "definition": "A unique identifier assigned to each candidate registered with the FEC. The initial character indicates the office sought. (H)ouse, (S)enate, (P)resident. If a person runs for several offices, they will have separate IDs for each office."
+  },
+  {
+    "term": "Cash-on-hand",
+    "definition": "Cash on hand includes funds held in checking and savings accounts, certificates of deposit, petty cash funds, traveler’s checks, treasury bills and other investments valued at cost. <a href=\"https://www.fec.gov/regulations/104-3/CURRENT#104-3-a-1\">11 CFR 104.3(a)(1)</a>."
+  },
+  {
+    "term": "CFR",
+    "definition": "Code of Federal Regulations. The annual collection of executive-agency regulations published in the daily Federal Register, combined with previously issued regulations that are still in effect. The sections of the CFR containing federal campaign finance regulations may be found in Title 11 and are <a href=\"https://www.fec.gov/regulations/\">available on the FEC’s website</a> or as a free publication from the FEC."
+  },
+  {
+    "term": "Clearly identified candidate",
+    "definition": "A candidate is clearly identified when his or her name, nickname, photograph or drawing appears, or when his or her identity is otherwise apparent through an unambiguous reference such as “the President,” “your Congressman,” or “the incumbent,” or through an unambiguous reference to his or her status as a candidate such as “the Democratic presidential nominee” or “the Republican candidate for Senate in the State of Georgia.” 11 CFR <a href=\"https://www.fec.gov/regulations/100-17/CURRENT#100-17\">100.17</a>."
+  },
+  {
+    "term": "Commercial vendor",
+    "definition": "Any person providing goods or services to a candidate or political committee whose usual and normal business involves the sale, rental, lease or provision of those goods or services. 11 CFR <a href=\"https://www.fec.gov/regulations/116-1/CURRENT#116-1-c\">116.1(c)</a>."
+  },
+  {
+    "term": "Committee type",
+    "definition": "A definition that categorizes groups organized to receive and spend money in federal elections. The basic committee types are authorized committees, political party committees, separate segregated funds (SSFs) and nonconnected committees."
+  },
+  {
+    "term": "Communications filers",
+    "definition": "Form 5, Form 7 and Form 9 filers, whose activity includes: <ul><li>Contributions reported by persons other than political committees</li><li>Independent expenditures reported by persons other than political committees</li><li>Communication costs reported by corporations and membership organizations</li><li>Electioneering communications</li></ul>"
+  },
+  {
+    "term": "Conduit or intermediary",
+    "definition": "Any person who receives and forwards an earmarked contribution to a candidate or a candidate’s authorized committee. 11 CFR <a href=\"https://www.fec.gov/regulations/110-6/CURRENT#110-6-b-2\">110.6(b)(2)</a>."
+  },
+  {
+    "term": "Connected organization",
+    "definition": "An organization that uses its treasury funds to establish, administer or solicit contributions to a separate segregated fund. 11 CFR <a href=\"https://www.fec.gov/regulations/100-6/CURRENT#100-6\">100.6(a)</a>."
+  },
+  {
+    "term": "Contribution",
+    "definition": "A gift, subscription, loan, advance or deposit of money or anything of value given to influence a federal election; or the payment by any person of compensation for the personal services of another person if those services are rendered without charge to a political committee for any purpose. 11 CFR <a href=\"https://www.fec.gov/regulations/100-52/CURRENT#100-52\">100.52(a)</a> and <a href=\"https://www.fec.gov/regulations/100-54/CURRENT#100-54\">100.54</a>."
+  },
+  {
+    "term": "Contribution in the name of another",
+    "definition": "Giving money or anything of value, all or part of which was provided to the contributor by another person (the true contributor) without disclosing the source of the money or the thing of value to the recipient candidate or committee at the time the contribution is made; or making a contribution of money or anything of value and attributing as the source another person when in fact the contributor is the source. <a href=\"https://www.fec.gov/regulations/110-4/CURRENT#110-4-b\">11 CFR 110.4(b)</a>."
+  },
+  {
+    "term": "Coordinated",
+    "definition": "Made in cooperation, consultation or concert with, or at the request or suggestion of, a candidate, a candidate’s authorized committee or their agents, or a political party committee or its agents. 11 CFR <a href=\"https://www.fec.gov/regulations/109-20/CURRENT#109-20\">109.20(a)</a>."
+  },
+  {
+    "term": "Coordinated communication",
+    "definition": "A communication that satisfies a three-pronged test: <ol class='list-bulleted'>><li>The communication must be paid for by a person other than a federal candidate, authorized committee, or a political party committee, or any agents of the aforementioned entities with whom the communication is coordinated.</li><li>One or more of the five content standards set forth in <a href=\"https://www.fec.gov/regulations/109-21/CURRENT#109-21-c\">11 CFR 109.21(c)</a> must be satisfied; and</li><li>One or more of the five conduct standards set forth in <a href=\"https://www.fec.gov/regulations/109-21/CURRENT#109-21-d\">11 CFR 109.21(d)</a> must be satisfied.</li></ol>A payment for a communication satisfying all three prongs is an in-kind contribution to the candidate or political party committee with which it was coordinated. 11 CFR <a href=\"https://www.fec.gov/regulations/109-21/CURRENT#109-21\">109.21</a>."
+  },
+  {
+    "term": "Coordinated party expenditure",
+    "definition": "A special type of expenditure that can be made only by a national or state political party committee in connection with the general election of a candidate. These expenditures are subject to a separate set of limits and do not count against the party’s normal contribution limits with respect to each candidate. 11 CFR <a href=\"https://www.fec.gov/regulations/109-30/CURRENT#109-30\">109.30</a> and <a href=\"https://www.fec.gov/regulations/109-32/CURRENT#109-32\">109.32-37</a>."
+  },
+  {
+    "term": "Corporation",
+    "definition": "Any separately incorporated entity (other than a political committee that has incorporated for liability purposes only). 11 CFR <a href=\"https://www.fec.gov/regulations/100-134/CURRENT#100-134-l\">100.134(l)</a> and <a href=\"https://www.fec.gov/regulations/114-12/CURRENT#114-12\">114.12(a)</a>. The term corporation covers both for-profit and nonprofit corporations and includes nonstock corporations, incorporated membership organizations, incorporated cooperatives, incorporated trade associations, professional corporations and, under certain circumstances, limited liability companies."
+  },
+  {
+    "term": "Custodian of Records",
+    "definition": "The individual or entity holding possession of a political committee’s books and accounts.The Custodian of Records is listed on the committee’s Statement of Organization. 11 CFR <a href=\"https://www.fec.gov/regulations/102-2/CURRENT#102-2-a-1-ii\">102.2(a)(1)(iii)</a>."
+  },
+  {
+    "term": "Date made",
+    "definition": "The date the contributor relinquishes control over a contribution. A contribution that is mailed is considered made on the date of the postmark. In the case of an in-kind contribution, a contribution is made on the date the goods or services are provided by the contributor. This date determines the election or calendar year limit against which a contribution counts. 11 CFR <a href=\"https://www.fec.gov/regulations/110-1/CURRENT#110-1-b-6\">110.1(b)(6)</a>."
+  },
+  {
+    "term": "Date received",
+    "definition": "The date a committee (or a person acting on the committee’s behalf) takes possession of the contribution. 11 CFR <a href=\"https://www.fec.gov/regulations/102-8/CURRENT#102-8\">102.8(a)</a>. This date is used for FEC reporting."
+  },
+  {
+    "term": "Debt",
+    "definition": "Debts include unpaid bills. FEC reports show the amount of reportable debt a committee owes to other entities at the end of the filing period."
+  },
+  {
+    "term": "Delegate",
+    "definition": "An individual who is or seeks to become a delegate to a national nominating convention or to a state, district or local convention, caucus or primary held to select delegates to a national nominating convention. 11 CFR <a href=\"https://www.fec.gov/regulations/110-14/CURRENT#110-14-b\">110.14(b)(1)</a>."
+  },
+  {
+    "term": "Delegate committee",
+    "definition": "A group organized for the purpose of influencing the selection of one or more delegates. The term includes a group of delegates, a group of individuals seeking to become delegates and a group of individuals supporting delegates. 11 CFR <a href=\"https://www.fec.gov/regulations/110-14/CURRENT#110-14-b-2\">110.14(b)(2)</a>."
+  },
+  {
+    "term": "Designated/designation",
+    "definition": "A contribution is considered to be designated in writing for a particular election if <ul class='list-bulleted'><li>The contribution is made by check, money order, or other negotiable instrument which clearly indicates the particular election with respect to which the contribution is made;</li><li>The contribution is accompanied by a writing, signed by the contributor, which clearly indicates the particular election with respect to which the contribution is made; or</li>The contribution is redesignated in accordance with <a href=\"https://www.fec.gov/regulations/110-1/CURRENT#110-1-b-4-iii\">11 CFR 110.1(b)(5)</a>.</li></ul> <a href=\"https://www.fec.gov/regulations/110-1/CURRENT#110-1-b-4\">11 CFR 110.1(b)(4)</a>."
+  },
+  {
+    "term": "Direct mail",
+    "definition": "Any mailings made by a commercial vendor or made from a commercial list. 11 CFR <a href=\"https://www.fec.gov/regulations/100-87/CURRENT#100-87\">100.87(a)</a>, <a href=\"https://www.fec.gov/regulations/100-89/CURRENT#100-89-a\">100.89(a)</a>, <a href=\"https://www.fec.gov/regulations/100-147/CURRENT#100-147-a\">100.147(a)</a> and <a href=\"https://www.fec.gov/regulations/100-149/CURRENT#100-149\">100.149(a)</a>"
+  },
+  {
+    "term": "Disbursement",
+    "definition": "Any purchase or payment made by a political committee or any other person that is subject to the Federal Election Campaign Act. 11 CFR <a href=\"https://www.fec.gov/regulations/300-2/CURRENT#300-2-d\">300.2(d)</a>."
+  },
+  {
+    "term": "Disclaimer notice",
+    "definition": "A “disclaimer” notice is a statement that identifies the person(s) who paid for a communication and whether the communication was authorized by one or more candidates. 11 CFR <a href=\"https://www.fec.gov/regulations/110-11/CURRENT#110-11\">110.11</a>."
+  },
+  {
+    "term": "District",
+    "definition": "A U.S. House of Representatives District. Because Senators represent an entire state, Senate races do not have districts associated with them."
+  },
+  {
+    "term": "Donation",
+    "definition": "A payment, gift, subscription, loan, advance, deposit or anything of value given to a person but does not include contributions.11 CFR <a href=\"https://www.fec.gov/regulations/300-2/CURRENT#300-2-d-2\">300.2(e)</a>."
+  },
+  {
+    "term": "Earmarked contribution",
+    "definition": "A contribution that the contributor directs (either orally or in writing) to or on behalf of a clearly identified candidate or authorized committee through an intermediary or conduit. Earmarking may take the form of a designation, instruction or encumbrance, and it may be direct or indirect, express or implied. 11 CFR <a href=\"https://www.fec.gov/regulations/110-6/CURRENT#110-6\">110.6</a>."
+  },
+  {
+    "term": "Election",
+    "definition": "Any one of several processes by which an individual seeks nomination for election, or election, to federal office. They include: a primary election, including a caucus or convention that has authority to select a nominee; a general election; a runoff election; and a special election held to fill a vacant seat. 11 CFR <a href=\"https://www.fec.gov/regulations/100-2/CURRENT#100-2\">100.2</a>."
+  },
+  {
+    "term": "Election cycle",
+    "definition": "The period beginning the day after the previous general election for a given federal office and ending on the date of the general election for that office. The number of years in an election cycle differs according to the federal office sought. The election cycle spans two years for House candidates; four years for presidential candidates; and six years for Senate candidates. See 11 CFR <a href=\"https://www.fec.gov/regulations/100-3/CURRENT#100-3-b\">100.3(b)</a>."
+  },
+  {
+    "term": "Electioneering communication",
+    "definition": "Any broadcast, cable or satellite communication that (1) refers to a clearly identified candidate for federal office; (2) is publicly distributed within certain time periods before an election and (3) is targeted to the relevant electorate. 11 CFR <a href=\"https://www.fec.gov/regulations/100-29/CURRENT#100-29\">100.29</a>."
+  },
+  {
+    "term": "Employer",
+    "definition": "The organization or person by whom an individual is employed, and not the name of his or her supervisor. <a href=\"https://www.fec.gov/regulations/100-21/CURRENT#100-21\">11 CFR 100.21</a>."
+  },
+  {
+    "term": "Ending cash-on-hand",
+    "definition": "The total amount of cash on hand that remains after the amount of cash-on-hand at the beginning of the reporting period is adjusted to add the total receipts for the reporting period and subtract the total disbursements for the reporting period."
+  },
+  {
+    "term": "Executive and administrative personnel",
+    "definition": "Individuals employed by a corporation or labor organization who are paid on a salary rather than hourly basis and who have policymaking, managerial, professional, or supervisory responsibilities. The definition does not include professionals who are represented by a labor organization, salaried foremen and lower-level supervisors having direct supervision over hourly employees, former or retired personnel who are not stockholders, and consultants who are not employees under the Internal Revenue Code. 11 CFR <a href=\"https://www.fec.gov/regulations/114-1/CURRENT#114-1-c\">114.1(c)</a>, <a href=\"https://www.ecfr.gov/cgi-bin/text-idx?SID=8fcc28cd0cc7d6262e5dbe3865335df0&mc=true&node=se26.17.31_13401_2c_3_61&rgn=div8\">26 CFR 31.3401(c)-1</a>."
+  },
+  {
+    "term": "Exempt party activities",
+    "definition": "Certain candidate support activities that state and local party groups may undertake without making a contribution or expenditure, provided specific rules are followed."
+  },
+  {
+    "term": "Expenditure",
+    "definition": "A purchase, payment, distribution, loan, advance, deposit or gift of money or anything of value made for the purpose of influencing a federal election. A written agreement to make an expenditure is also considered an expenditure. 11 CFR <a href=\"https://www.fec.gov/regulations/100-111/CURRENT#100-111\">100.111</a> and <a href=\"https://www.fec.gov/regulations/100-112/CURRENT#100-112\">100.112</a>."
+  },
+  {
+    "term": "Express advocacy",
+    "definition": "Unambiguously advocating the election or defeat of a clearly identified federal candidate. There are two ways that a communication can be defined as express advocacy (candidate advocacy): by use of certain “explicit words of advocacy of election or defeat” and by the “only reasonable interpretation” test. See 11 CFR <a href=\"https://www.fec.gov/regulations/100-22/CURRENT#100-22\">100.22</a>."
+  },
+  {
+    "term": "Facilitation",
+    "definition": "The use of corporate or labor organization resources or facilities to engage in fundraising activities in connection with any federal election (other than raising funds for the organization’s separate segregated fund). Facilitation results in a prohibited contribution to the committee that benefits from the activity. 11 CFR <a href=\"https://www.fec.gov/regulations/114-2/CURRENT#114-2-f\">114.2(f)</a>."
+  },
+  {
+    "term": "Family",
+    "definition": "For purposes of the rules governing fundraising by corporate/labor/trade PACs, the Commission views the term \"family\" to mean the spouses, parents, and children who live in the same household. Spouse is defined by state law. See <a href=\"https://www.fec.gov/data/legal/advisory-opinions/2013-06\">AOs 2013-06</a> and <a href=\"https://www.fec.gov/data/legal/advisory-opinions/1980-102\">1980-102</a>. For purposes of the rules governing the use of campaign funds by candidates, a candidate’s family includes the candidate’s spouse, any child, step-child, parent, grandparent, sibling, half-sibling or step-sibling of the candidate or the candidate's spouse, the spouse of any child, step-child, parent, grandparent, sibling, half-sibling or step-sibling of the candidate; and any person who shares a residence with the candidate. See 11 CFR  <a href=\"https://www.fec.gov/regulations/113-1/CURRENT#113-1-g-7\">113.1(g)(7)</a>. Publicly funded presidential candidates should refer to 11 CFR <a href=\"https://www.fec.gov/regulations/9003-2/CURRENT#9003-2-c-1\">9003.2(c)(1)</a> and <a href=\"https://www.fec.gov/regulations/9035-2/2017-annual-9035#9035-2-b\">9035.2(b)</a>."
+  },
+  {
+    "term": "Federal Election Activity (FEA)",
+    "definition": "Activity by state, district and local party committees, which may be paid for with federal or – in the case of the first two types – a combination of federal and Levin funds. The four types of federal election activity are as follows:<ul class=\"list-numbered\"><li>Voter registration activity during the period 120 days before a primary or general election and ending on election day itself;</li><li>Voter identification, get-out-the-vote and generic campaign activity conducted in connection with an election in which a federal candidate appears on the ballot;</li><li>A public communication that refers to a clearly identified candidate for federal office and that promotes, attacks, supports or opposes any candidate for federal office. The communication does not need to expressly advocate the election or defeat of the federal candidate to qualify as federal election activity; and </li><li>Services provided during a month by an employee of a state, district or local party committee who spends more than 25 percent of his or her compensated time during that month on activities in connection with a federal election including FEA.</li></ul> 11 CFR <a href=\"https://www.fec.gov/regulations/100-24/CURRENT#100-24-b\">100.24(b)</a>."
+  },
+  {
+    "term": "Federal funds",
+    "definition": "Funds that comply with the limits, prohibitions and reporting requirements of the Federal Election Campaign Act. 11 CFR <a href=\"https://www.fec.gov/regulations/300-2/CURRENT#300-2-g\">300.2(g)</a>."
+  },
+  {
+    "term": "Federal government contractor",
+    "definition": "A person who enters into a contract, or is bidding on such a contract, with any agency or department of the United States government and is paid, or is to be paid, for services, material, equipment, supplies, land or buildings with funds appropriated by Congress. 11 CFR <a href=\"https://www.fec.gov/regulations/115-1/CURRENT#115-1\">115.1</a>."
+  },
+  {
+    "term": "Federal officeholder",
+    "definition": "An individual elected to or serving in the office of President or Vice President of the United States, or a Senator or Representative in, or a Delegate or Resident Commissioner, to the Congress of the United States. 11 CFR <a href=\"https://www.fec.gov/regulations/113-1/CURRENT#113-1-c\">113.1(c)</a> and <a href=\"https://www.fec.gov/regulations/300-2/CURRENT#300-2-o\">300.2(o)</a>."
+  },
+  {
+    "term": "Federally chartered corporation",
+    "definition": "A corporation that is organized pursuant to a federal statute and that became a corporation when it received a charter from a federal agency. See <a href=\"https://www.fec.gov/data/legal/advisory-opinions/1988-12\">AOs 1988-12</a> and <a href=\"https://www.fec.gov/data/legal/advisory-opinions/1984-63\">1984-63</a>."
+  },
+  {
+    "term": "Filing",
+    "definition": "A report, designation or statement submitted to the FEC or Secretary of the Senate by a candidate, committee or other entity. Required filings include declarations of candidacy and committee reports of the money they receive and spend.  See also \"Reports, designations and statements\"."
+  },
+  {
+    "term": "Foreign national",
+    "definition": "<ol><li> An individual who is not a citizen of the United States or a national of the United States and has not been lawfully admitted to the U.S. for permanent residence, as defined in 8 U.S.C. § 1101(a)(20); or</li><li>A foreign principal, as defined in 22 U.S.C. § 611(b).</li></ol> 11 CFR <a href=\"https://www.fec.gov/regulations/110-20/CURRENT#110-20-a\">110.20(a)(3)</a>."
+  },
+  {
+    "term": "Generic campaign activity",
+    "definition": "A type of Federal Election Activity, as distinguished from voter drive activity. Generic campaign activity is a public communication that promotes or opposes a political party and does not promote or oppose a clearly identified federal candidate or a nonfederal candidate. 11 CFR <a href=\"https://www.fec.gov/regulations/100-25/CURRENT#100-25\">100.25</a>."
+  },
+  {
+    "term": "Get-Out-The-Vote (GOTV)",
+    "definition": "In regard to FEA, GOTV activity encompasses all means of assisting, encouraging or urging potential voters to vote. This activity includes, but is not limited to: <ul><li>Encouraging or urging potential voters to vote, whether by mail (including direct mail), email, in person, by telephone (including prerecorded telephone calls, phone banks and messaging such as SMS and MMS), or by any other means;</li><li>Informing potential voters, whether by mail (including direct mail), email, in person, by telephone (including pre-recorded telephone calls, phone banks and messaging such as SMS and MMS), or by any other means, about the hours or location of polling places, or about early voting or voting by absentee ballot;</li><li>Offering or arranging to transport, or actually transporting voters to the polls;</li><li>Any other activity that assists potential voters in voting.</li></ul> 11 CFR <a href=\"https://www.fec.gov/regulations/100-24/CURRENT#100-24-a-3\">100.24(a)(3)</a>."
+  },
+  {
+    "term": "Hybrid PAC",
+    "definition": "A committee that, in addition to making contributions, establishes a separate bank account to deposit and withdraw funds raised in unlimited amounts from individuals, corporations, labor organizations and/or other political committees, consistent with the stipulated judgment in <i>Carey v. FEC</i>. The funds maintained in this separate account will not be used to make contributions, whether direct, in-kind or via coordinated communications, or coordinated expenditures, to federal candidates or committees."
+  },
+  {
+    "term": "Identification",
+    "definition": "For purposes of recordkeeping and reporting, a person’s full name and address and, in the case of an individual, his or her occupation (principal job title or position) and employer (organization or person by whom an individual is employed) as well. 11 CFR <a href=\"https://www.fec.gov/regulations/100-12/CURRENT#100-12\">100.12</a>, <a href=\"https://www.fec.gov/regulations/100-20/CURRENT#100-20\">100.20</a> and <a href=\"https://www.fec.gov/regulations/100-21/CURRENT#100-21\">100.21</a>."
+  },
+  {
+    "term": "In-kind contribution",
+    "definition": "A contribution of goods, services or property offered free or at less than the usual and normal charge. The term also includes payments made on behalf of, but not directly to, candidates and political committees (except for independent expenditures or non-coordinated communications). 11 CFR <a href=\"https://www.fec.gov/regulations/100-52/CURRENT#100-52-d\">100.52(d)</a>."
+  },
+  {
+    "term": "Independent expenditure",
+    "definition": "An expenditure for a communication <ul><li>That expressly advocates the election or defeat of a clearly identified candidate and</li><li>That is not made in cooperation, consultation or concert with, or at the request or suggestion of, any candidate, or his or her authorized committees or agents, or a political party committee or its agents. 11 CFR <a href=\"https://www.fec.gov/regulations/100-16/CURRENT#100-16\">100.16</a>.</li></ul>"
+  },
+  {
+    "term": "Independent expenditure only committee",
+    "definition": "A political committee that makes only independent expenditures may solicit and accept unlimited contributions from individuals, corporations, labor organizations and other political committees. It may not accept contributions from foreign nationals, federal contractors, national banks or federally chartered corporations. See <a href=\"https://www.fec.gov/data/legal/advisory-opinions/2010-11/\">AO 2010-11</a>. Such committees, popularly known as Super PACs, must register with the Commission and comply with all applicable reporting requirements of the Act."
+  },
+  {
+    "term": "Joint contribution",
+    "definition": "A contribution made by more than one person on a single check or other written instrument. 11 CFR <a href=\"https://www.fec.gov/regulations/110-1/CURRENT#110-1-k\">110.1(k)(1)</a>."
+  },
+  {
+    "term": "Joint fundraising",
+    "definition": "Fundraising conducted jointly by a political committee and one or more other political committees or unregistered organizations.  Joint fundraising is often conducted between a principal campaign committee and a political party committee."
+  },
+  {
+    "term": "Joint fundraising committee",
+    "definition": "A committee that has been set up for the purposes of fundraising for multiple committees at the same time or an existing committee that has been authorized to serve that purpose."
+  },
+  {
+    "term": "Labor organization",
+    "definition": "An organization, agency or employee representative committee or plan, in which employees participate and which exists for the purpose of dealing with employers on grievances, labor disputes, wages, hours of employment or working conditions. 11 CFR <a href=\"https://www.fec.gov/regulations/114-1/CURRENT#114-1-d\">114.1(d)</a>."
+  },
+  {
+    "term": "Leadership PAC",
+    "definition": "A political committee that is directly or indirectly established, financed, maintained or controlled by a candidate or an individual holding federal office, but is not an authorized committee of the candidate or officeholder and is not affiliated with an authorized committee of a candidate or officeholder."
+  },
+  {
+    "term": "Levin funds",
+    "definition": "A category of funds raised by state, district and local party committees that may be spent for certain Federal Election Activities. Levin funds are donations from sources ordinarily prohibited by federal law but permitted by state law. 11 CFR <a href=\"https://www.fec.gov/regulations/300-31/CURRENT#300-31\">300.31</a> and <a href=\"https://www.fec.gov/regulations/300-32/CURRENT#300-32\">300.32</a>."
+  },
+  {
+    "term": "Limited liability company (LLC)",
+    "definition": "A business entity that is recognized as a limited liability company under the laws of the state in which it is established. LLCs that are treated as partnerships under the IRS code may make contributions. LLCs that have publicly traded stock or are treated as corporations under the IRS code are prohibited from making contributions. 11 CFR <a href=\"https://www.fec.gov/regulations/110-1/CURRENT#110-1-g\">110.1(g)</a>."
+  },
+  {
+    "term": "Lobbyist/registrant",
+    "definition": "A person who is a current registrant under the Lobbying Disclosure Act, or an individual who is named on a current registration or report filed under the Lobbying Disclosure Act. See 11 CFR <a href=\"https://www.fec.gov/regulations/104-22/CURRENT#104-22\">104.22</a>."
+  },
+  {
+    "term": "Lobbyist/Registrant PAC",
+    "definition": "Any political committee established or controlled by a person who is a current registrant under Lobbying Disclosure Act or an individual who is named on a current registration or report filed under the Lobbying Disclosure Act."
+  },
+  {
+    "term": "Local or district party committee",
+    "definition": "A political committee that, by virtue of the bylaws of a political party, is responsible for the day-to-day operation of a political party at a level lower than the state level (e.g., city, county, ward). 11 CFR <a href=\"https://www.fec.gov/regulations/100-14/CURRENT#100-14-b\">100.14(b)</a>."
+  },
+  {
+    "term": "Local party organization",
+    "definition": "A local party organization is an organization that is responsible for a political party's activities below the state level (such as city, county or district level) but is not registered with the Federal Election Commission as a district or local party committee."
+  },
+  {
+    "term": "Major party",
+    "definition": "A political party whose candidate in the preceding presidential election received, as the candidate of such party, 25 percent or more of the popular vote. 11 CFR <a href=\"https://www.fec.gov/regulations/9002-6/CURRENT#9002-6\">9002.6</a> and <a href=\"https://www.fec.gov/regulations/9008-2/CURRENT#9008-2\">9008.2(c)</a>."
+  },
+  {
+    "term": "Matter Under Review (MUR)",
+    "definition": "An FEC enforcement action, initiated by a sworn complaint or by an internal administrative action."
+  },
+  {
+    "term": "Member",
+    "definition": "With respect to a labor organization, a trade association, a cooperative or other incorporated membership organization, a member is an individual or other entity that: <ul><li>Satisfies the requirements for membership in a membership organization;</li><li> affirmatively accepts the organization’s invitation to become a member; and</li><li>maintains a long-term and continuous bond with the organization by:<ul><li>having a significant financial attachment, such as a significant investment or ownership stake;</li><li>paying annual dues; or</li><li>having direct participatory rights in the governance of the organization.</li></ul></li></ul> 11 CFR <a href=\"https://www.fec.gov/regulations/114-1/CURRENT#114-1-e-2\">114.1(e)(2)</a>."
+  },
+  {
+    "term": "Membership organization",
+    "definition": "A labor organization or a trade association, cooperative or other incorporated membership organization that:<ul><li>is composed of members;</li><li>expressly states the qualifications for membership in its articles and by-laws;</li><li>makes its articles, by-laws and other organizational documents available to its members;</li><li>expressly seeks members;</li><li>acknowledges the acceptance of membership, such as by sending membership cards to new members or including them on a membership newsletter list; and</li><li>is not organized primarily for the purpose of influencing a federal election.</li></ul> 11 CFR <a href=\"https://www.fec.gov/regulations/100-134/CURRENT#100-134-e\">100.134(e)</a> and <a href=\"https://www.fec.gov/regulations/114-1/CURRENT#114-1-e\">114.1(e)(1)</a>."
+  },
+  {
+    "term": "Memo entry/memo item",
+    "definition": "Supplemental or explanatory information on a reporting schedule. A memo entry is often used to disclose additional information about an itemized transaction that is included in the total receipts or disbursements for the current report or a previous report. The dollar amount in a memo entry is not incorporated into the total figure for the schedule."
+  },
+  {
+    "term": "Memo text",
+    "definition": "A field offered in FECFile software and some commercial software to allow a committee to provide additional text to describe a particular transaction it is reporting."
+  },
+  {
+    "term": "Multicandidate committee",
+    "definition": "A political action committee or party committee that has been registered at least 6 months, has more than 50 contributors and, with the exception of state party committees, has made contributions to at least 5 candidates for federal office. 11 CFR <a href=\"https://www.fec.gov/regulations/100-5/CURRENT#100-5-e-3\">100.5(e)(3)</a>."
+  },
+  {
+    "term": "National bank",
+    "definition": "A bank that is subject to the supervision of the <a href=\"https://www.helpwithmybank.gov/dictionary/index-dictionary.html#N\">Comptroller of the Currency</a>. The Office of the Comptroller of the Currency is a bureau of the U.S. Treasury Department."
+  },
+  {
+    "term": "National committee",
+    "definition": "An organization that, by virtue of the bylaws of a political party, is responsible for the day-to-day operation of the political party at the national level, as determined by the Commission. 11 CFR <a href=\"https://www.fec.gov/regulations/100-13/CURRENT#100-13\">100.13</a>."
+  },
+  {
+    "term": "National party committee",
+    "definition": "A political committee established and maintained by a national political party. A party’s national committee, House campaign committee and Senate campaign committee are considered national party committees, as determined by the Commission. 11 CFR <a href=\"https://www.fec.gov/regulations/110-1/CURRENT#110-1-c-2\">110.1(c)(2)</a>; <a href=\"https://www.fec.gov/regulations/110-2/CURRENT#110-2-c-2\">110.2(c)(2)</a>; <a href=\"https://www.fec.gov/regulations/110-3/CURRENT#110-3-b-1-ii\">110.3(b)(2)</a>."
+  },
+  {
+    "term": "Net debts outstanding",
+    "definition": "The total of a campaign’s unpaid debts incurred with respect to an election plus estimated costs to liquidate the debts plus costs of terminating political activity (if appropriate) minus cash on hand and receivables. 11 CFR <a href=\"https://www.fec.gov/regulations/110-1/CURRENT#110-1-b-3-ii\">110.1(b)(3)(ii)</a>."
+  },
+  {
+    "term": "Nonconnected committee",
+    "definition": "Any committee that conducts activities in connection with an election, but that is not a party committee, an authorized committee of any candidate for federal election, or a separate segregated fund. 11 CFR <a href=\"https://www.fec.gov/regulations/100-6/CURRENT#100-6\">106.6(a)</a>."
+  },
+  {
+    "term": "Non-contribution account",
+    "definition": "A separate bank account to deposit and withdraw funds raised in unlimited amounts from individuals, corporations, labor organizations and/or other political committees, consistent with the stipulated judgment in <i>Carey v. FEC</i>. The funds maintained in this separate account will not be used to make contributions, whether direct, in-kind or via coordinated communications, or coordinated expenditures, to federal candidates or committees."
+  },
+  {
+    "term": "None",
+    "definition": "If data appears as \"None\", it's best to check the source document. Common reasons that the data appears as \"None\" are:<ul><li>Data is not processed yet; often, paper filings cause delays and inconsistent upload times.</li><li>Data is from an amendment that did not properly identify the form it was amending.</li><li>The filer did not fill out the information on the form.</li></ul>If you think there is an error, you can report that via our feedback tool."
+  },
+  {
+    "term": "Nonfederal funds",
+    "definition": "Funds that are not subject to the limitations or prohibitions of the Federal Election Campaign Act. 11 CFR <a href=\"https://www.fec.gov/regulations/300-2/CURRENT#300-2-k\">300.2(k)</a>."
+  },
+  {
+    "term": "Occupation",
+    "definition": "The principal job title or position of an individual and whether or not self-employed. 11 CFR <a href=\"https://www.fec.gov/regulations/100-20/CURRENT#100-20\">100.20</a>."
+  },
+  {
+    "term": "One-third rule",
+    "definition": "A formula used to ensure the treasury funds of a connected organization are not traded for voluntary contributions when the organization pays for prizes or entertainment to offer as an incentive to make a contribution to its SSF. Under the one-third rule, the SSF must reimburse the connected organization for costs that exceed one-third of the money raised. See 11 CFR <a href=\"https://www.fec.gov/regulations/114-5/CURRENT#114-5-b-2\">114.5(b)(2)</a>."
+  },
+  {
+    "term": "Ongoing committee",
+    "definition": "Any political committee that has not terminated and does not qualify as a terminating committee. 11 CFR <a href=\"https://www.fec.gov/regulations/116-1/CURRENT#116-1-b\">116.1(b)</a>."
+  },
+  {
+    "term": "Operating expenditures",
+    "definition": "A committee's day-to-day expenditures for items such as rent, overhead, administration, personnel, equipment, travel, advertising and fundraising."
+  },
+  {
+    "term": "Ordinary course of business",
+    "definition": "In determining whether credit was extended in the ordinary course of business, the Commission will consider—<ul class='list-bulleted'><li>Whether the commercial vendor followed its established procedures and its past practice in approving the extension of credit;</li><li>Whether the commercial vendor received prompt payment in full if it previously extended credit to the same candidate or political committee; and</li><li>Whether the extension of credit conformed to the usual and normal practice in the commercial vendor's trade or industry. </li></ul> 11 CFR <a href=\"https://www.fec.gov/regulations/116-3/CURRENT#116-3-c\">116.3(c)</a>."
+  },
+  {
+    "term": "Organization type",
+    "definition": "Certain filers, like separate segregated funds and communication cost filers, identify the types of organizations they are connected with. These connected organizations can be identified as corporations, trade associations, labor organizations, cooperatives, membership organizations or corporations without capital stock."
+  },
+  {
+    "term": "Overnight delivery service",
+    "definition": "A private delivery service business of established reliability that offers an overnight (next business day) delivery option."
+  },
+  {
+    "term": "Party committee",
+    "definition": "A political committee that represents a political party and is part of the official party structure at the national, state or local level."
+  },
+  {
+    "term": "PASO",
+    "definition": "PASO is an acronym that stands for “Promote, Attack, Support or Oppose.” See, e.g., 11 CFR <a href=\"https://www.fec.gov/regulations/100-24/CURRENT#100-24-b-3\">100.24(b)(3)</a>."
+  },
+  {
+    "term": "Person",
+    "definition": "An individual, partnership, political committee, corporation, labor organization or any other organization or group of persons, not including the federal government. 11 CFR <a href=\"https://www.fec.gov/regulations/100-10/CURRENT#100-10\">100.10</a>."
+  },
+  {
+    "term": "Personal funds of a candidate",
+    "definition": "The personal funds of a candidate include: <ul class='list-bulleted'><li>Assets which the candidate has a legal right of access to or control over, and which he or she has legal title to or an equitable interest in, at the time of candidacy;</li><li>Income from employment;</li><li>Dividends and interest from, and proceeds from sale or liquidation of, stocks and other investments;</li><li>Income from trusts, if established before the election cycle;</li><li>Income from trusts established by bequests (even after candidacy)</li><li>Bequests to the candidate;</li><li>Personal gifts that had been customarily received by the candidate prior to the beginning of the election cycle; and</li><li>Proceeds from lotteries and similar games of chance.</li></ul> 11 CFR <a href=\"https://www.fec.gov/regulations/100-33/CURRENT#100-33\">100.33(a) and (b)</a>."
+  },
+  {
+    "term": "Political Action Committee (PAC)",
+    "definition": "Popular term for a political committee that is neither a party committee nor an authorized committee of a candidate. PACs directly or indirectly established, administered or financially supported by a corporation or labor organization are called separate segregated funds (SSFs). PACs without such a corporate or labor sponsor are called nonconnected PACs."
+  },
+  {
+    "term": "Political committee",
+    "definition": "An entity that meets one of the following conditions:<ul><li>An authorized committee of a candidate (see definition of candidate)</li><li>Any club, association or other group of persons that receives contributions or makes expenditures, either of which aggregate over $1,000 during a calendar year</li><li>A local unit of a political party (except a state party committee) that: (1) receives contributions aggregating over $5,000 during a calendar year; (2) makes contributions or expenditures either of which aggregate over $1,000 during a calendar year or (3) makes payments aggregating over $5,000 during a calendar year for certain activities that are exempt from the definitions of contribution and expenditure (11 CFR <a href=\"https://www.fec.gov/regulations/100-80/CURRENT#100-80\">100.80</a>, <a href=\"https://www.fec.gov/regulations/100-87/CURRENT#100-87\">100.87</a> and <a href=\"https://www.fec.gov/regulations/100-89/CURRENT#100-89\">100.89</a>; 11 CFR <a href=\"https://www.fec.gov/regulations/100-140/CURRENT#100-140\">100.140</a>, <a href=\"https://www.fec.gov/regulations/100-140/CURRENT#100-147>100.147</a> and <a href=\"https://www.fec.gov/regulations/100-149/CURRENT#100-149\">100.149</a>).</li><li>Any separate segregated fund upon its establishment. 11 CFR <a href=\"https://www.fec.gov/regulations/100-5/CURRENT#100-5-b\">100.5</a>.</li></ul>"
+  },
+  {
+    "term": "Political party",
+    "definition": "An association, committee or organization that nominates or selects a candidate for election to federal office whose name appears on the election ballot as the candidate of the organization."
+  },
+  {
+    "term": "Postmarked",
+    "definition": "A U.S. Postal Service postmark or the verifiable date of deposit with an overnight delivery service."
+  },
+  {
+    "term": "Presidential public funds",
+    "definition": "Public funding of presidential elections means that qualified presidential candidates may choose to receive federal government funds to pay for certain expenses of their political campaigns in both the primary and general elections. Prior to the 2016 presidential election, national political parties could also receive federal money for their national nominating conventions."
+  },
+  {
+    "term": "Principal campaign committee",
+    "definition": "An authorized committee designated by a candidate as the principal committee to raise contributions and make expenditures for his or her campaign for a federal office."
+  },
+  {
+    "term": "Prior approval",
+    "definition": "A written request to a member corporation of a trade association to a member corporation for permission to solicit the member’s restricted class. This request for approval must inform the member corporation that corporate approval is necessary before the trade association or its SSF may conduct a solicitation and the corporation may not approve solicitations by another trade association for the same calendar year. 11 CFR <a href=\"https://www.fec.gov/regulations/114-8/CURRENT#114-8-d-3\">114.8(d)(3)</a>."
+  },
+  {
+    "term": "Public communication",
+    "definition": "A communication by means of any broadcast, cable or satellite communication, newspaper, magazine, outdoor advertising facility, mass mailing or telephone bank to the general public, or any other form of general public political advertising. The term general public political advertising does not include communications made over the internet, except for communications placed for a fee on another person’s website. 11 CFR <a href=\"https://www.fec.gov/regulations/100-26/CURRENT#100-26\">100.26</a>, <a href=\"https://www.fec.gov/regulations/100-27/CURRENT#100-27\">100.27</a> (definition of mass mailing) and <a href=\"https://www.fec.gov/regulations/100-28/CURRENT#100-28\">100.28</a> (definition of telephone bank)."
+  },
+  {
+    "term": "Qualified/non-qualified",
+    "definition": "In the context of multicandidate political committees identified in FEC data reports and indices, the designation “qualified” or “non-qualified” reflects whether a political committee has satisfied the criteria for multicandidate political committee status (i.e., whether the committee has been registered for at least 6 months, received contributions from more than 50 persons, and made contributions to 5 or more federal candidates). Committees listed as “non-qualified” do not satisfy these requirements. See 11 CFR <a href=\"https://www.fec.gov/regulations/100-5/CURRENT#100-5-e-3\">100.5(e)(3)</a>."
+  },
+  {
+    "term": "Reattributed contribution",
+    "definition": "The portion of an excessive contribution that has been attributed in writing to another contributor and signed by both contributors. 11 CFR <a href=\"https://www.fec.gov/regulations/110-1/CURRENT#110-1-k-3-ii\">110.1(k)(3)(ii)</a>."
+  },
+  {
+    "term": "Receipt",
+    "definition": "Anything of value (money, goods, services or property) received by a political committee."
+  },
+  {
+    "term": "Redesignated contribution",
+    "definition": "With regard to contributions made to candidates, the portion of a contribution that has been designated by the contributor, in writing, to an election other than the one for which the funds were originally given. 11 CFR <a href=\"https://www.fec.gov/regulations/110-1/CURRENT#110-1-b-4-iii\">110.1(b)(5)</a>."
+  },
+  {
+    "term": "Refunded contribution",
+    "definition": "A contribution is refunded when the recipient committee deposits the contribution and sends the contributor a check for the amount (or a portion) of the contribution. 11 CFR <a href=\"https://www.fec.gov/regulations/103-3/CURRENT#103-3-b\">103.3(b)</a>."
+  },
+  {
+    "term": "Reports, designations and statements",
+    "definition": "All committees registered with the FEC and other persons who make certain expenditures or disbursements are required to file reports, designations and statements that disclose their financial activity. The contents of those reports and statements, as well as the filing schedule, depend on the type of committee or organization, or the type of expenditure or disbursement made.  See also \"Filing.\"."
+  },
+  {
+    "term": "Restricted class/solicitable class",
+    "definition": "Those persons, including the executive and administrative personnel, members or stockholders (and the families of each) within a corporation or labor organization, who may be solicited for contributions to the organization’s separate segregated fund at any time and who may receive certain communications from the organization. 11 CFR <a href=\"https://www.fec.gov/regulations/114-1/CURRENT#114-1-j\">114.1(j)</a>; <a href=\"https://www.fec.gov/regulations/114-3/CURRENT#114-3\">114.3(a)</a>; <a href=\"https://www.fec.gov/regulations/114-5/CURRENT#114-5-g\">114.5(g)</a>; <a href=\"https://www.fec.gov/regulations/114-7/CURRENT#114-7\">114.7(a) and (h)</a>; and <a href=\"https://www.fec.gov/regulations/114-8/CURRENT#114-8-c\">114.8(c), (h) and (i)</a>."
+  },
+  {
+    "term": "Separate segregated fund (SSF)",
+    "definition": "A political committee established, administered or financially supported by a corporation or labor organization, popularly called a Corporate or Labor Political Action Committee (PAC). See 11 CFR <a href=\"https://www.fec.gov/regulations/114-1/CURRENT#114-1-a-2\">114.1(a)(2)(iii)</a>. The term \"financially supported\" does not include contributions to the SSF, but does include the payment of establishment, administration or solicitation costs. <a href=\"https://www.fec.gov/regulations/100-6/CURRENT#100-6-c\">11 CFR 100.6(c)</a>."
+  },
+  {
+    "term": "Solicitation (SSF)",
+    "definition": "A statement that publicizes the SSF’s right to accept unsolicited contributions from any lawful contributor; provides information on how to contribute to the SSF; or encourages support for the SSF. <a href=\"https://www.fec.gov/data/legal/advisory-opinions/1984-55/\">AO 1984–55, n. 2</a>; AOs <a href=\"https://www.fec.gov/data/legal/advisory-opinions/1979-66/\">1979–66</a> and <a href=\"https://www.fec.gov/data/legal/advisory-opinions/1979-13/\">1979–13</a>."
+  },
+  {
+    "term": "Special election",
+    "definition": "A primary, general or runoff election that is not a regularly scheduled election and that is held to fill a vacant seat in the House of Representatives or the Senate. <a href=\"https://www.fec.gov/regulations/100-2/CURRENT#100-2-f\">100.2(f)</a>."
+  },
+  {
+    "term": "State party committee",
+    "definition": "A committee which, by virtue of the bylaws of a political party or the operation of state law is part of the official party structure and is responsible for the day-to-day operation of the party at the state level, including an entity that is directly or indirectly established, financed, maintained or controlled by that organization, as determined by the Commission. 11 CFR <a href=\"https://www.fec.gov/regulations/100-14/CURRENT#100-14\">100.14(a)</a>."
+  },
+  {
+    "term": "Status",
+    "definition": "Refers to whether the candidate is an incumbent, challenger or running unopposed."
+  },
+  {
+    "term": "Stockholder",
+    "definition": "A person who has a vested beneficial interest in stock, the power to direct how that stock is voted (if it is voting stock) and the right to receive dividends.11 CFR <a href=\"https://www.fec.gov/regulations/114-1/CURRENT#114-1-h\">114.1(h)</a>."
+  },
+  {
+    "term": "Super PAC",
+    "definition": "A political committee that makes only independent expenditures may solicit and accept unlimited contributions from individuals, corporations, labor organizations and other political committees. It may not accept contributions from foreign nationals, federal contractors, national banks or federally chartered corporations. See <a href=\"https://www.fec.gov/data/legal/advisory-opinions/2010-11/\">AO 2010-11</a>. Such committees, also known as independent expenditure only committees, must register with the Commission and comply with all applicable reporting requirements of the Act."
+  },
+  {
+    "term": "Terminating committee",
+    "definition": "A political committee that is winding down its activities in preparation for filing a termination report. A terminating committee has ceased to make or receive contributions or make expenditures (other than for debt retirement purposes or winding-down costs). 11 CFR <a href=\"https://www.fec.gov/regulations/116-1/CURRENT#116-1\">116.1(a)</a>."
+  },
+  {
+    "term": "to Direct",
+    "definition": "For purposes of 11 CFR Part 300, to direct means to guide, directly or indirectly, a person who has expressed an intent to make a contribution, donation, transfer of funds or otherwise provide anything of value, by identifying a candidate, political committee or organization for the receipt of such funds or things of value. The contribution, donation, transfer or thing of value may be provided directly or through an intermediary. Direction does not include merely providing information or guidance as to the applicability of a particular law or regulation. 11 CFR <a href=\"https://www.fec.gov/regulations/300-2/2017-annual-300#300-2-n\">300.2(n)</a>."
+  },
+  {
+    "term": "to Solicit",
+    "definition": "For the purposes of 11 CFR <a href=\"https://www.fec.gov/regulations/300\">Part 300</a>, to solicit means to ask, request or recommend, explicitly or implicitly, that another person make a contribution, donation, transfer of funds or otherwise provide anything of value. A solicitation is an oral or written communication that, construed as reasonably understood in the context in which it is made, contains a clear message asking, requesting or recommending that a person make a contribution, donation, transfer of funds or otherwise provide anything of value. A solicitation may be made directly or indirectly. The context includes the conduct of persons involved in the communication. A solicitation does not include mere statements of political support or mere guidance as to the applicability of a particular law or regulation. 11 CFR <a href=\"https://www.fec.gov/regulations/300-2/CURRENT#300-2-l\">300.2(m)</a>."
+  },
+  {
+    "term": "Total disbursements",
+    "definition": "The sum of all purchases and payments made during a filing period by a political committee or any other person, including an organization that is not a political committee that is subject to the Federal Election Campaign Act."
+  },
+  {
+    "term": "Total receipts",
+    "definition": "The sum of all contributions and other receipts received by a committee during a filing period."
+  },
+  {
+    "term": "Trade association",
+    "definition": "A membership organization consisting of persons engaged in a similar or related line of commerce. A trade association is organized to promote and improve business conditions in that line of commerce and not to engage in a regular business for profit. No part of the net earnings of a trade association may inure to the benefit of any member."
+  },
+  {
+    "term": "Treasurer",
+    "definition": "Required for every political committee. The treasurer is responsible for filing the committee's registration form, depositing receipts, authorizing expenditures, monitoring contributions, keeping records, signing all reports and statements and filing all reports and statements on time."
+  },
+  {
+    "term": "Treasury funds",
+    "definition": "Funds of a corporation or labor organization that are derived from commercial activities or dues payments. Treasury funds may be used for the establishment, administrative and fundraising costs of the organization’s separate segregated fund, as well as for making independent expenditures and contributing to Super PACs and the non-contribution accounts of Hybrid PACs. See 11 CFR <a href=\"https://www.fec.gov/regulations/114-5/CURRENT#114-5-b\">114.5(b)</a> and <a href=\"https://www.fec.gov/regulations/114-10/CURRENT#114-10\">114.10</a>."
+  },
+  {
+    "term": "Undesignated contribution",
+    "definition": "Contributors may designate contributions for a particular election by indicating in writing the specific election to which they intend a contribution to apply. A contribution that is not designated by the contributor for a specific election is an undesignated contribution. Undesignated contributions count against the donor’s contribution limits for the candidate’s next election. 11 CFR <a href=\"https://www.fec.gov/regulations/110-1/CURRENT#110-1-b-2-ii\">110.1(b)(2)</a>."
+  },
+  {
+    "term": "Unique identifier",
+    "definition": "A unique title or code assigned by a party committee to each program or event for which it reports an allocation ratio. Party committees must use that identifier consistently when reporting the activity. 11 CFR <a href=\"https://www.fec.gov/regulations/104-17/CURRENT#104-17-b-1-iii\">104.17(b)(1)(iii)</a>."
+  },
+  {
+    "term": "U.S.C.",
+    "definition": "The United States Code (U.S.C.) contains the federal statutory laws of the United States, arranged into 54 broad titles according to subject matter. The FEC administers the <a href=\"https://www.fec.gov/data/legal/statutes/\">campaign finance laws</a> found in Title 52 and the portions of Title 26 of the United States Code concerning public financing of presidential election campaigns."
+  },
+  {
+    "term": "Usual and normal charge",
+    "definition": "With regard to goods provided to a political committee, the term refers to the price of those goods in the market from which they ordinarily would have been purchased at the time they were provided. With regard to services, the term refers to the hourly or piecework charge for the services at a commercially reasonable rate prevailing at the time the services were rendered. 11 CFR <a href=\"https://www.fec.gov/regulations/100-52/CURRENT#100-52-d-2\">100.52(d)(2)</a>."
+  },
+  {
+    "term": "Voter drive activity",
+    "definition": "Voter identification, voter registration and get-out-the-vote-drives, or any other activities that urge the general public to register or vote, or that promote or oppose a political party, without promoting any federal or nonfederal candidate, that do not qualify as FEA. This is a category of allocable activity for mixed federal/nonfederal party activity sometimes also referred to as a “generic voter drive.” 11 CFR <a href=\"https://www.fec.gov/regulations/106-7/CURRENT#106-7-c-5\">106.7(c)(5)</a>."
+  },
+  {
+    "term": "Voter identification",
+    "definition": "With regard to FEA, this means acquiring information about potential voters, including, but not limited to, obtaining voter lists and creating or enhancing voter lists by verifying or adding information about the voters’ likelihood of voting in an upcoming election or voting for specific candidates. 11 CFR <a href=\"https://www.fec.gov/regulations/100-24/CURRENT#100-24-a-4\">100.24(a)(4)</a>."
+  },
+  {
+    "term": "Voter registration activity",
+    "definition": "In regard to FEA, voter registration activity encompasses all means of contacting potential voters to assist, encourage or urge them to register to vote. This activity includes, but is not limited to: <ul><li>Encouraging or urging potential voters to register to vote, whether by mail (including direct mail), email, in person, by telephone (including pre-recorded telephone calls, phone banks and messaging such as SMS and MMS), or by any other means;</li><li>Preparing and distributing information about registration and voting;</li><li>Distributing voter registration forms or instructions to potential voters;</li><li>Answering questions about how to complete or file a voter registration form, or assisting potential voters in completing or filing such forms;</li><li>Submitting or delivering a completed voter registration form on behalf of a potential voter;</li><li>Offering or arranging to transport, or actually transporting potential voters to a board of elections or county clerk’s office for them to fill out voter registration forms; or</li><li>any other activity that assists potential voters to register to vote.</li></ul> 11 CFR <a href=\"https://www.fec.gov/regulations/100-24/CURRENT#100-24-a-2\">100.24(a)(2)</a>."
+  }
+]

--- a/fec_eregs/static/fec_eregs/js/fec.js
+++ b/fec_eregs/static/fec_eregs/js/fec.js
@@ -2,7 +2,11 @@
 //
 // The main entrypoint for fec-eregs specific javascript.
 
+var $ = require('jquery');
+
 var SiteNav = require('./site-nav').SiteNav;
+var Glossary = require('glossary-panel');
+var terms = require('./data/terms')
 
 var $ = window.$;
 $(function () {
@@ -12,4 +16,11 @@ $(function () {
       webAppUrl: window.WEB_URL
     });
   });
+new Glossary(terms, {}, {
+    termClass: 'glossary__term accordion__button',
+    definitionClass: 'glossary__definition accordion__content'
+  });
 });
+
+
+

--- a/fec_eregs/static/fec_eregs/js/site-nav.js
+++ b/fec_eregs/static/fec_eregs/js/site-nav.js
@@ -10,6 +10,7 @@ var TEMPLATES = {
   data: require('./templates/nav-data.hbs'),
   legal: require('./templates/nav-legal.hbs'),
   help: require('./templates/nav-help.hbs'),
+  about: require('./templates/nav-about.hbs')
 };
 
 /** SiteNav module

--- a/fec_eregs/static/fec_eregs/js/templates/nav-about.hbs
+++ b/fec_eregs/static/fec_eregs/js/templates/nav-about.hbs
@@ -1,0 +1,27 @@
+<div class="mega-container">
+  <div class="mega mega--secondary">
+    <div class="mega__inner">
+      <div class="row">
+        <div class="usa-width-one-fourth">
+          <h2 class="mega-heading__title icon-heading--data-flag-circle--secondary"><a href="/about/">Learn more about the FEC</a></h2>
+        </div>
+        <div class="usa-width-one-half mega__intro">
+          <ul class="usa-width-one-third">
+           <li class="mega__item"><a href="/updates">News and announcements</a></li>
+           <li class="mega__item"><a href="/meetings">Commission meetings</a></li>
+           <li class="mega__item"><a href="/about/mission-and-history/">Mission and history</a></li>
+          </ul>
+          <ul class="usa-width-one-third">
+            <li class="mega__item"><a href="/about/leadership-and-structure/">Leadership and structure</a></li>
+            <li class="mega__item"><a href="/about/reports-about-fec/">Reports about the FEC</a></li>
+            <li class="mega__item"><a href="/about/careers/">Careers</a></li>
+           </ul>
+           <ul class="usa-width-one-third">
+            <li class="mega__item"><a href="/about/#working-with-the-fec">Working with the FEC</a></li>
+            <li class="mega__item"><a href="/contact-us">Contact</a></li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/fec_eregs/static/fec_eregs/js/templates/nav-data.hbs
+++ b/fec_eregs/static/fec_eregs/js/templates/nav-data.hbs
@@ -1,49 +1,28 @@
 <div class="mega-container">
   <div class="mega">
     <div class="mega__inner">
-      <div class="mega-heading">
-        <h2 class="mega-heading__title"><a href="/data">Campaign finance home</a></h2>
-      </div>
       <div class="row">
-        <div class="usa-width-one-third mega__intro">
-          <p>Look up candidates and committees in federal elections and learn about the money raised and spent in elections.</p>
-          <p><a class="button button--alt-primary" href="/data">Get started &raquo;</a></p>
+        <div class="usa-width-one-fourth">
+          <h2 class="mega-heading__title icon-heading--data-flag-circle--primary"><a href="/data">Explore all data</a></h2>
         </div>
-        <div class="usa-width-one-third">
-          <ul class="usa-width-one-half">
+        <div class="usa-width-one-third mega__intro">
+          <ul class="t-sans list--2-columns u-padding--top">
             <li class="mega__item"><a href="/data/advanced?tab=raising">Raising</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=spending">Spending</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=loans-debts">Loans and debts</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=filings">Filings and reports</a></li>
-          </ul>
-          <ul class="usa-width-one-half">
             <li class="mega__item"><a href="/data/advanced?tab=candidates">Candidates</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=committees">Committees</a></li>
-            <li class="mega__item"><a href="/data/advanced?tab=other">Bulk data and other sources</a></li>
-            <li class="mega__item"><a href="/data/advanced?tab=external">External sources</a></li>
+            <li class="mega__item"><a href="/data/advanced?tab=bulk-data">Bulk data</a></li>
           </ul>
         </div>
-        <div class="usa-width-one-fourth u-margin--top u-padding--left">
-          <a href="/data/elections">
-            <aside class="card card--primary card--horizontal mega__card">
-              <div class="card__image">
-                <span class="card__icon i-elections"><span class="u-visually-hidden">Icon representing elections</span></span>
-              </div>
-              <div class="card__content">
-                Find elections. Search by state or ZIP code.
-              </div>
-            </aside>
-          </a>
-          <a href="/data/receipts/individual-contributions">
-            <aside class="card card--primary card--horizontal mega__card">
-              <div class="card__image">
-                <span class="card__icon i-individual-contributions"><span class="u-visually-hidden">Icon representing individual contributions</span></span>
-              </div>
-              <div class="card__content">
-                Look up contributions from specific individuals
-              </div>
-            </aside>
-          </a>
+        <div class="usa-width-one-third u-padding--left">
+          <div class="icon-heading icon-heading--person-location-circle">
+            <p class="t-sans t-small icon-heading__text"><a href="/data/elections">Find elections. Search by state or ZIP code</a></p>
+          </div>
+          <div class="icon-heading icon-heading--individual-contributions-circle">
+            <p class="t-sans t-small icon-heading__text"> <a href="/data/receipts/individual-contributions">Look up contributions from specific individuals</a></p>
+          </div>
         </div>
       </div>
     </div>

--- a/fec_eregs/static/fec_eregs/js/templates/nav-data.hbs
+++ b/fec_eregs/static/fec_eregs/js/templates/nav-data.hbs
@@ -14,6 +14,7 @@
             <li class="mega__item"><a href="/data/advanced?tab=candidates">Candidates</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=committees">Committees</a></li>
             <li class="mega__item"><a href="/data/advanced?tab=bulk-data">Bulk data</a></li>
+            <li class="mega__item"><a href="/data/advanced/?tab=historical">Historical statistics</a></li>
           </ul>
         </div>
         <div class="usa-width-one-third u-padding--left">

--- a/fec_eregs/static/fec_eregs/js/templates/nav-help.hbs
+++ b/fec_eregs/static/fec_eregs/js/templates/nav-help.hbs
@@ -1,23 +1,28 @@
 <div class="mega-container">
   <div class="mega mega--secondary">
     <div class="mega__inner">
-      <div class="mega-heading">
-        <h2 class="mega-heading__title"><a href="/help-candidates-and-committees">Candidates and committees home</a></h2>
-      </div>
       <div class="row">
+        <div class="usa-width-one-fourth">
+          <h2 class="mega-heading__title icon-heading--data-flag-circle--secondary"><a href="/help-candidates-and-committees/">Explore all compliance resources</a></h2>
+      </div>
         <div class="usa-width-one-third mega__intro">
-          <p>Learn more about the groups that are active in federal elections and the requirements that apply to them.</p>
-          <p><a href="/help-candidates-and-committees" class="button button--alt-primary">Get started &raquo;</a></p>
+          <ul class="t-sans list--2-columns u-padding--top">
+            <li class="mega__item"><a href="/help-candidates-and-committees/guides">Guides</a></li>
+            <li class="mega__item"><a href="/help-candidates-and-committees/forms">Forms</a></li>
+            <li class="mega__item"><a  href="/help-candidates-and-committees/dates-and-deadlines">Dates and deadlines</a></li>
+            <li class="mega__item"><a  href="https://transition.fec.gov/info/outreach.shtml">Trainings</a></li>
+          </ul>
         </div>
-        <ul class="usa-width-one-third mega__list">
-          <li><a class="mega__page-link" href="/help-candidates-and-committees#campaign-guidance">Campaign guidance</a></li>
-          <li><a class="mega__page-link" href="/help-candidates-and-committees/forms">Forms</a></li>
-        </ul>
-        <ul class="usa-width-one-third mega__list">
-          <li><a class="mega__page-link" href="/help-candidates-and-committees/dates-and-deadlines">Dates and deadlines</a></li>
-          <li><a class="mega__page-link" href="https://transition.fec.gov/info/outreach.shtml">Trainings</a></li>
-        </ul>
+        <div class="usa-width-one-third u-padding--left">
+          <div class="icon-heading icon-heading--checklist-circle">
+            <p class="t-sans t-small icon-heading__text"><a href="/help-candidates-and-committees/filing-reports/electronic-filing/">Learn about electronic filing</a></p>
+          </div>
+          <div class="icon-heading icon-heading--question-bubble-circle">
+            <p class="t-sans t-small icon-heading__text"> <a href="/help-candidates-and-committees/question-rad/">Find and contact your committee's analyst</a></p>
+          </div>
+        </div>
       </div>
     </div>
   </div>
 </div>
+

--- a/fec_eregs/static/fec_eregs/js/templates/nav-legal.hbs
+++ b/fec_eregs/static/fec_eregs/js/templates/nav-legal.hbs
@@ -1,25 +1,26 @@
 <div class="mega-container">
   <div class="mega">
     <div class="mega__inner">
-      <div class="mega-heading">
-        <h2 class="mega-heading__title"><a href="/legal-resources">Legal home</a></h2>
-      </div>
       <div class="row">
-        <div class="usa-width-one-third mega__intro">
-          <p>Explore relevant statutes, regulations, Commission actions and court cases.</p>
-          <p><a href="/legal-resources" class="button button--alt-primary">Get started &raquo;</a></p>
+        <div class="usa-width-one-fourth">
+          <h2 class="mega-heading__title icon-heading--data-flag-circle--primary"><a href="/legal-resources">Explore all legal resources</a></h2>
         </div>
-        <ul class="usa-width-one-third mega__list">
-          <li><a class="mega__page-link" href="/data/legal/advisory-opinions">Advisory opinions</a></li>
-          <li><a class="mega__page-link" href="/legal-resources/enforcement">Enforcement</a></li>
-          <li><a class="mega__page-link" href="/data/legal/statutes">Statutes</a></li>
-          <li><a class="mega__page-link" href="/legal-resources/legislation">Legislation</a></li>
-        </ul>
-        <ul class="usa-width-one-third mega__list">
-          <li><a class="mega__page-link" href="/legal-resources/regulations">Regulations</a></li>
-          <li><a class="mega__page-link" href="/legal-resources/court-cases">Court cases</a></li>
-          <li><a class="mega__page-link" href="https://transition.fec.gov/law/policy.shtml">Policy and other guidance</a></li>
-        </ul>
+        <div class="usa-width-one-third mega__intro">
+          <ul class="t-sans list--2-columns u-padding--top">
+            <li class="mega__item"><a href="/data/legal/advisory-opinions">Advisory opinions</a></li>
+            <li class="mega__item"><a href="/legal-resources/enforcement">Enforcement</a></li>
+            <li class="mega__item"><a href="/data/legal/statutes">Statutes</a></li>
+            <li class="mega__item"><a href="/legal-resources/legislation">Legislation</a></li>
+            <li class="mega__item"><a href="/legal-resources/regulations">Regulations</a></li>
+            <li class="mega__item"><a href="/legal-resources/court-cases">Court cases</a></li>
+            <li class="mega__item"><a href="https://transition.fec.gov/law/policy.shtml">Policy and other guidance</a></li>
+          </ul>
+        </div>
+        <div class="usa-width-one-fourth u-padding--left">
+          <div class="icon-heading icon-heading--magnifying-glass-circle">
+            <p class="t-sans t-small icon-heading__text"><a href="/legal-resources/">Search across all legal resources</a></p>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/fec_eregs/static/fec_eregs/scss/_custom-mega-menu.scss
+++ b/fec_eregs/static/fec_eregs/scss/_custom-mega-menu.scss
@@ -23,10 +23,25 @@
 
 .mega__inner {
   padding: u(1rem);
+  margin: u(1rem 0 0 0);
+
+  ul.u-padding--top{
+    margin-top: u(2rem);
+  }
 }
 
+
 .mega-heading__title {
-  display: none;
+
+  a {
+    border-bottom: 1px dotted $inverse !important;
+    color: $inverse;
+  }
+  &::before {
+    margin-bottom: u(3rem);
+    height: u(5rem) !important;
+    width: u(5rem) !important;
+  }
 }
 
 .mega-heading {
@@ -34,7 +49,7 @@
 }
 
 .mega__intro {
-  padding: u(1rem 1rem 0 1rem);
+  padding: u(0rem 1rem 0 1rem);
 }
 
 .mega__page-link {
@@ -72,9 +87,10 @@
 .mega__item {
   margin-bottom: u(1.5rem);
   padding-left: u(2rem);
+  line-height: 1.2;
 
   &:first-of-type {
-    margin-top: u(1rem);
+    margin-top: 0;
   }
 }
 
@@ -162,6 +178,19 @@
       .mega__page-link {
         border-bottom: none;
       }
+    }
+  }
+}
+
+@media screen and (max-width: 720px){
+  .mega-heading__title{
+    margin-left: u(1rem);
+    margin-top: u(1rem);
+    margin-bottom: u(3rem);
+
+    &::before {
+      margin-top: u(-.5rem);
+      margin-bottom: u(0rem);
     }
   }
 }

--- a/fec_eregs/static/fec_eregs/scss/components/_accordions.scss
+++ b/fec_eregs/static/fec_eregs/scss/components/_accordions.scss
@@ -1,0 +1,96 @@
+// Accordions
+//
+// .accordion--neutral         - No background, dark buttons
+// .accordion--inverse         - Dark background, light buttons
+//
+// <ul class="js-accordion" data-content-prefix="first">
+//   <li>
+//     <button class="accordion__button">
+//       First Item
+//     </button>
+//     <div class="accordion__content">
+//       <p>
+//         First Item Content
+//       </p>
+//     </div>
+//   </li>
+//   <li>
+//     <button class="accordion__button">
+//       Second Item
+//     </button>
+//     <div class="accordion__content">
+//       <p>
+//         Second Item Content
+//       </p>
+//     </div>
+//   </li>
+// </ul>
+//
+
+.accordion__button {
+  @include u-icon-bg($plus-circle, $primary);
+  background-size: u(2rem);
+  background-position: 95% 50%;
+  border-bottom: 1px solid $base;
+  margin: 0 0 -1px 0;
+  color: $base;
+  font-size: u(1.4rem);
+  font-weight: bold;
+  letter-spacing: -.3px;
+  padding: u(1rem 4rem 1rem 2rem);
+  text-align: left;
+  width: 100%;
+
+  &[aria-expanded='true'] {
+    @include u-icon-bg($minus-circle, $primary);
+    border-bottom: none;
+  }
+}
+
+.accordion__content {
+  @include clearfix();
+  border-bottom: 1px solid $base;
+  padding: u(2rem);
+  font-family: $sans-serif;
+}
+
+.accordion__button--spacious {
+  padding: u(2rem 4rem 2rem 2rem);
+}
+
+.accordion--neutral {
+  .accordion__button {
+    background-color: $gray-lightest;
+    border-top: 1px solid $primary;
+
+    &[aria-expanded='true'] {
+      background-color: $gray-light;
+      border-top: 1px solid $base;
+      border-bottom: 2px solid $gray;
+    }
+  }
+
+  .accordion__content {
+    background-color: $gray-light;
+    border-bottom-color: $base;
+    border-top-color: $gray;
+  }
+}
+
+.accordion--inverse {
+  .accordion__button {
+    @include u-icon-bg($plus-circle, $inverse);
+    background-position: 100% 50%;
+    border-color: $inverse;
+    color: $inverse;
+
+    &[aria-expanded='true'] {
+      @include u-icon-bg($minus-circle, $inverse);
+    }
+  }
+
+  .accordion__content {
+    @include u-font-color($inverse);
+    border-color: $inverse;
+  }
+}

--- a/fec_eregs/static/fec_eregs/scss/components/_glossary.scss
+++ b/fec_eregs/static/fec_eregs/scss/components/_glossary.scss
@@ -32,10 +32,22 @@
 
   h2 {
     color: $inverse;
+    margin: 0 0 1em 0;
+    font-size: 1.4rem;
+    font-weight: 700;
   }
 
   .label {
     color: $inverse;
+  }
+
+  input{
+  height: 29px;
+  padding:1px;
+  }
+
+  .accordion__button{
+    height:auto;
   }
 }
 

--- a/fec_eregs/static/fec_eregs/scss/components/_icon-headings.scss
+++ b/fec_eregs/static/fec_eregs/scss/components/_icon-headings.scss
@@ -13,6 +13,11 @@
 
 .icon-heading {
   @include clearfix();
+  margin-top:0;
+
+  @include media($med) {
+    margin-top: u(1rem);
+  }
 }
 
 .icon-heading__image {
@@ -60,6 +65,8 @@
   padding-left: u(3rem);
 }
 
+
+
 .icon-heading--raising-circle {
   &::before {
     $size: u(4rem);
@@ -80,11 +87,34 @@
   }
 }
 
+.icon-heading--data-flag-circle--primary {
+  &::before {
+    $size: u(4rem);
+    @include u-icon-circle($data-flag, $inverse, $primary-contrast, $size);
+    background-size: 50%;
+    content: '';
+    float: left;
+    margin-right: u(1.5rem);
+  }
+}
+
+.icon-heading--data-flag-circle--secondary {
+  &::before {
+    $size: u(4rem);
+    @include u-icon-circle($data-flag, $inverse, $secondary-contrast, $size);
+    background-size: 50%;
+    content: '';
+    float: left;
+    margin-right: u(1.5rem);
+  }
+}
+
 // homepage - registration and reporting (on secondary [red] slab)
 .icon-heading--checklist-circle {
   &::before {
-    @include u-icon-circle($checklist, $inverse, $secondary-contrast, 4.5rem);
-    background-size: u(4rem);
+    $size: u(4rem);
+    @include u-icon-circle($checklist, $inverse, $secondary-contrast, $size);
+    background-size: 70%;
     content: '';
     float: left;
     margin-right: u(1.5rem);
@@ -93,8 +123,9 @@
 
 .icon-heading--question-bubble-circle {
   &::before {
-    @include u-icon-circle($question-bubble, $inverse, $secondary-contrast, 4.5rem);
-    background-size: u(4rem);
+    $size: u(4rem);
+    @include u-icon-circle($question-bubble, $inverse, $secondary-contrast, $size);
+    background-size: 70%;
     content: '';
     float: left;
     margin-right: u(1.5rem);
@@ -170,6 +201,39 @@
   }
 }
 
+.icon-heading--person-location-circle {
+  &::before {
+    $size: u(4rem);
+    @include u-icon-circle($person-location, $inverse, $primary-contrast, $size);
+    background-size: 50%;
+    content: '';
+    float: left;
+    margin-right: u(1.5rem);
+  }
+}
+
+.icon-heading--individual-contributions-circle {
+  &::before {
+    $size: u(4rem);
+    @include u-icon-circle($individual-contributions, $inverse, $primary-contrast, $size);
+    background-size: 50%;
+    content: '';
+    float: left;
+    margin-right: u(1.5rem);
+  }
+}
+
+.icon-heading--magnifying-glass-circle {
+  &::before {
+    $size: u(4rem);
+    @include u-icon-circle($magnifying-glass, $inverse, $primary-contrast, $size);
+    background-size: 50%;
+    content: '';
+    float: left;
+    margin-right: u(1.5rem);
+  }
+}
+
 // Data landing page links to breakdowns
 .icon-heading--graph-circle {
   &::before {
@@ -207,14 +271,24 @@
 
 .icon-heading--graph-circle,
 .icon-heading--graph-unordered-circle,
-.icon-heading--map-circle {
+.icon-heading--map-circle,
+.icon-heading--data-flag-circle,
+.icon-heading--question-bubble-circle,
+.icon-heading--checklist-circle,
+.icon-heading--magnifying-glass-circle,
+.icon-heading--question-bubble-circle,
+.icon-heading--individual-contributions-circle,
+.icon-heading--person-location-circle
+ {
   border-bottom: none;
   display: table;
+  padding-bottom: u(1.3rem);
 
   .icon-heading__text {
     line-height: 1.2;
     display: table-cell;
     vertical-align: middle;
+    color:inherit;
   }
 
   &::before {

--- a/fec_eregs/static/fec_eregs/scss/components/_list-styles.scss
+++ b/fec_eregs/static/fec_eregs/scss/components/_list-styles.scss
@@ -8,6 +8,8 @@
 // .list--numbered      - Numbered list (for ol)
 // .list--flat          - Lay out items horizontally
 // .list--spacious      - Adds padding above and below list items
+// .list--columns       - layout list in two or three columns based on screen size
+// .list--columns--two  - layout list in two columns
 //
 // <ul class="list--bulleted">
 //  <li>Unordered list item 1</li>
@@ -48,6 +50,11 @@
 }
 
 .list--numbered {
+
+  & > li {
+    list-style-type: decimal;
+  }
+
   ul {
     margin-bottom: 0;
     margin-left: u(1.5rem);
@@ -62,6 +69,10 @@
 
     ol li {
       list-style-type: lower-roman;
+    }
+
+    li {
+      list-style-type: decimal;
     }
   }
 }
@@ -79,12 +90,6 @@
 
   ul li {
     list-style-type: none;
-  }
-}
-
-.list--numbered {
-  li {
-    list-style-type: decimal;
   }
 }
 
@@ -129,7 +134,13 @@
   }
 }
 
-.list--columns {
+.list--2-columns {
+  @include media($lg) {
+    @include columns(2)
+  }
+}
+
+.list--3-columns {
   @include media($med) {
     @include columns(2)
   }

--- a/fec_eregs/static/fec_eregs/scss/components/_nav.scss
+++ b/fec_eregs/static/fec_eregs/scss/components/_nav.scss
@@ -125,6 +125,7 @@
 // Panel titles on mobile
 .site-nav__title {
   border-bottom: 1px solid $inverse;
+  color: $inverse;
   padding: u(1rem 1rem);
   margin: 0;
 }
@@ -143,6 +144,7 @@
     $top: u(11.6rem);
     height: calc(100vh - #{$top});
     top: $top;
+
   }
 
   .site-nav__button {
@@ -168,6 +170,7 @@
     position: relative;
     top: 0;
     width: 100%;
+    background:$inverse;
   }
 
   .site-nav__panel {

--- a/fec_eregs/static/fec_eregs/scss/components/_type-styles.scss
+++ b/fec_eregs/static/fec_eregs/scss/components/_type-styles.scss
@@ -1,0 +1,48 @@
+// Glossary
+//
+
+.t-note {
+  display: inline-block;
+  font-family: $serif;
+  font-weight: normal;
+  font-style: italic;
+  font-size: u(1.4rem);
+}
+
+.t-block {
+  display: block;
+}
+
+.t-inline-block {
+  display: inline-block;
+}
+
+.t-sans {
+  font-family: $sans-serif;
+  letter-spacing: -.3px;
+}
+
+.t-serif {
+  font-family: $serif;
+}
+
+.t-italic {
+  font-style: italic;
+}
+
+.t-bold {
+  font-weight: bold;
+}
+
+.t-underline {
+  text-decoration: underline;
+}
+
+.t-normal {
+  font-weight: normal;
+  font-style: normal;
+}
+
+.t-upper {
+  text-transform: uppercase;
+}

--- a/fec_eregs/static/fec_eregs/scss/elements/_typography.scss
+++ b/fec_eregs/static/fec_eregs/scss/elements/_typography.scss
@@ -84,3 +84,5 @@ blockquote {
   font-style: italic;
   margin-left: 0;
 }
+
+

--- a/fec_eregs/static/fec_eregs/scss/main.scss
+++ b/fec_eregs/static/fec_eregs/scss/main.scss
@@ -38,6 +38,7 @@ $x-large-screen: 1100px;
 @import 'elements/tables';
 @import 'elements/images';
 
+@import 'components/accordions';
 @import 'components/breadcrumbs';
 @import 'components/buttons';
 @import 'components/cards';
@@ -49,6 +50,7 @@ $x-large-screen: 1100px;
 @import 'components/page-headers';
 @import 'components/search-bar';
 @import 'components/site-header';
+@import 'components/type-styles';
 
 @import 'custom-headings';
 @import 'custom-mega-menu';

--- a/fec_eregs/templates/regulations/glossary.html
+++ b/fec_eregs/templates/regulations/glossary.html
@@ -1,0 +1,15 @@
+<div id="glossary" class="glossary"
+    aria-describedby="glossary-result" aria-hidden="true">
+  <button
+      title="Close glossary"
+      class="button button--close--inverse toggle js-glossary-close"
+    ><span class="u-visually-hidden">Hide glossary</span>
+  </button>
+  <h2>Glossary</h2>
+  <label for="glossary-search" class="label">Search terms</label>
+  <input id="glossary-search" class="glossary__search js-glossary-search" type="search">
+  <span class="t-note t-sans search__example">Examples: receipt; Hybrid PAC</span>
+  <div class="glossary__content" id="glossary-result">
+    <ul class="glossary__list js-glossary-list accordion--inverse"></ul>
+  </div>
+</div>

--- a/fec_eregs/templates/regulations/main-header.html
+++ b/fec_eregs/templates/regulations/main-header.html
@@ -10,7 +10,7 @@
     <a href="{{ FEC_CMS_URL }}/" title="Home" class="site-title"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
     <ul class="utility-nav list--flat">
       <li class="utility-nav__item"><a href="{{ FEC_CMS_URL }}/calendar/">Calendar</a></li>
-      <li class="utility-nav__item is-disabled"><span class="js-glossary-toggle glossary__toggle">Glossary</span></li>
+      <li class="utility-nav__item"><a class="js-glossary-toggle glossary__toggle">Glossary</a></li>
       <li class="utility-nav__search">
         <form accept-charset="UTF-8" action="{{ FEC_CMS_URL }}/search" class="combo" method="get" role="search">
           <input type="hidden" name="type" value="candidates">
@@ -55,6 +55,12 @@
             <span class="site-nav__link__title">Legal resources</span>
           </a>
         </li>
+        <li class="site-nav__item--secondary" data-submenu="about">
+          <a href="{{ FEC_CMS_URL }}/about" class="site-nav__link">
+            <span class="site-nav__link__title">About</span>
+          </a>
+        </li>
+
         <li class="site-nav__item utility-nav__item u-under-lg-only">
           <a href="{{ FEC_CMS_URL }}/calendar" class="site-nav__link">Calendar</a>
         </li>
@@ -105,4 +111,5 @@
       {% endif %}
     </ul>
   </div>
+  {% include 'regulations/glossary.html' %}
 </div>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "browserify": "^13.0.0",
+    "glossary-panel": "1.0.0",
     "grunt": "^0.4.5",
     "grunt-contrib-copy": "^1.0.0",
     "grunt-sass": "^2.0.0",


### PR DESCRIPTION
Resolves: #407, #409
- Implemented glossary on Eregs, matching fec-cms styles as closely as possible given the differing styles of eregs
- Added new mega-menu designs and added About menu which was not there.
### [How to test &#187;](#how-to-test)

There are still some responsive issues with the mega menu that are present on production as well:
- [ ]  All menu items default to open below the medium breakpoint (currently like this on production)
- [ ]  There are some minor spacing issues where the menu and the masthead content meet (currently like this on production)
 For a followup issue I am going to take a pass at solving this by removing the handlebars templates for the menus and replacing them with normal partials( like we do on fec-cms). I seem to remember @xtine saying that we no longer needed to use handlebars for the menus on production and perhaps it was just never also changed on Eregs.
<img width="1661" alt="screen shot 2018-07-06 at 3 16 36 pm" src="https://user-images.githubusercontent.com/5572856/42396453-aeea20ce-812f-11e8-845f-f1d7ab4bdb79.png">

<a id="how-to-test"></a> 

### How to test:|
- Checkout this branch locally `feature/update-headers-fix-glossary-link`
- `npm install`
- `npm run build`
- `./python manage.py compile_frontend`
- `./manage.py runserver`
- go to http://127.0.0.1:8000/
- Check the mega menu and make sure the about menu is there
- Test the glossary
Thanks for your time!