### PR TITLE
Set eregs caching to 1h

### DIFF
--- a/fec_eregs/settings/prod.py
+++ b/fec_eregs/settings/prod.py
@@ -46,3 +46,5 @@ HTTP_AUTH_PASSWORD = env.get_credential('HTTP_AUTH_PASSWORD')
 STATIC_URL = '/regulations/static/'
 API_BASE = 'http://localhost:{}/regulations/api/'.format(
     os.environ.get('PORT', '8000'))
+
+CACHES['eregs_longterm_cache']['TIMEOUT'] = 60 * 60


### PR DESCRIPTION
Resolves fecgov/fec-eregs#408

To test, deploy this to a cloud.gov space and execute:
```
curl -I $URL/regulations/1-2/2018-annual-1#1-2
```

You should see the following header in the response:
```
Cache-Control: max-age=3600
```

Without this change, you should see:
```
Cache-Control: max-age=1296000
```