### PR TITLE
Remove elasticsearch  service for eregs app.

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -4,7 +4,6 @@ command: python manage.py migrate --fake-initial && gunicorn -k gevent -w 2 --bi
 services:
   - fec-eregs-creds # Must provide HTTP_AUTH_USER, HTTP_AUTH_PASSWORD
   - fec-eregs-db
-  - fec-eregs-search
   - fec-creds-dev
 env:
   NEW_RELIC_CONFIG_FILE: /home/vcap/app/newrelic.ini

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -4,7 +4,6 @@ command: python manage.py migrate --fake-initial && gunicorn -k gevent -w 2 --bi
 services:
   - fec-eregs-creds # Must provide HTTP_AUTH_USER, HTTP_AUTH_PASSWORD
   - fec-eregs-db
-  - fec-eregs-search
   - fec-creds-prod
 env:
   NEW_RELIC_CONFIG_FILE: /home/vcap/app/newrelic.ini

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -4,7 +4,6 @@ command: python manage.py migrate --fake-initial && gunicorn -k gevent -w 2 --bi
 services:
   - fec-eregs-creds # Must provide HTTP_AUTH_USER, HTTP_AUTH_PASSWORD
   - fec-eregs-db
-  - fec-eregs-search
   - fec-creds-stage
 env:
   NEW_RELIC_CONFIG_FILE: /home/vcap/app/newrelic.ini


### PR DESCRIPTION
**Overview:**
Annual regulations are parsed and saved in a `aws shared database` instance. `eregs` app  do not need  `elasticsearch24`  or `elasticsearch56` services. 

**Changes :**
1. Removed the `fec-eregs-search` service from  dev/stage/prod manifest files.
2. Deleted below two elasticsearch24 services from `dev` space that are unused anywhere in our apps.
- fec-eregs-search                            
- fec-api-search     

**How to test:**
Search the regulations in `development` environment. You should be able to search and view the regulations here:  `https://fec-dev-proxy.app.cloud.gov/regulations`
