### PR TITLE
upgrade requests to the latest version 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ regcore==4.2.0
 # django, cached-property, six already covered
 enum34==1.1.6
 futures==3.1.1
-requests==2.18.4
+requests==2.21.0
 boto3==1.5.13
 celery==4.1.0
 requests-toolbelt==0.8.0


### PR DESCRIPTION

## Summary (required)
upgrade the request module to the latest version in requirements.txt .
- Resolves https://github.com/fecgov/fec-eregs/issues/422

## How to test the changes locally

1. install the requirements.txt
2. follow the eregs env set up instructions
3. export the API_BASE env variable to point to `dev` or `stage` or`production` api
4. run the server.
5. Regs should appear here : http://localhost:8000/
