### PR TITLE
updated data nav to point to renamed browse-data section

### DIFF
--- a/fec_eregs/static/fec_eregs/js/templates/nav-data.hbs
+++ b/fec_eregs/static/fec_eregs/js/templates/nav-data.hbs
@@ -7,14 +7,14 @@
         </div>
         <div class="usa-width-one-third mega__intro">
           <ul class="t-sans list--2-columns u-padding--top">
-            <li class="mega__item"><a href="/data/advanced?tab=raising">Raising</a></li>
-            <li class="mega__item"><a href="/data/advanced?tab=spending">Spending</a></li>
-            <li class="mega__item"><a href="/data/advanced?tab=loans-debts">Loans and debts</a></li>
-            <li class="mega__item"><a href="/data/advanced?tab=filings">Filings and reports</a></li>
-            <li class="mega__item"><a href="/data/advanced?tab=candidates">Candidates</a></li>
-            <li class="mega__item"><a href="/data/advanced?tab=committees">Committees</a></li>
-            <li class="mega__item"><a href="/data/advanced?tab=bulk-data">Bulk data</a></li>
-            <li class="mega__item"><a href="/data/advanced/?tab=historical">Historical statistics</a></li>
+            <li class="mega__item"><a href="/data/browse-data?tab=raising">Raising</a></li>
+            <li class="mega__item"><a href="/data/browse-data?tab=spending">Spending</a></li>
+            <li class="mega__item"><a href="/data/browse-data?tab=loans-debts">Loans and debts</a></li>
+            <li class="mega__item"><a href="/data/browse-data?tab=filings">Filings and reports</a></li>
+            <li class="mega__item"><a href="/data/browse-data?tab=candidates">Candidates</a></li>
+            <li class="mega__item"><a href="/data/browse-data?tab=committees">Committees</a></li>
+            <li class="mega__item"><a href="/data/browse-data?tab=bulk-data">Bulk data</a></li>
+            <li class="mega__item"><a href="/data/browse-data/?tab=historical">Historical statistics</a></li>
           </ul>
         </div>
         <div class="usa-width-one-third u-padding--left">


### PR DESCRIPTION
## Summary (required)

- Resolves # 2306 
_Modified data nav section links from "/data/advanced" to "/data/browse-data"._

### Related PRs

- **fec-cms** - https://github.com/fecgov/fec-cms/pull/2581
- **Proxy** - https://github.com/fecgov/fec-proxy/pull/105

## Impacted areas of the application
List general components of the application that this PR will affect:

- Data navigation changed to browse-data section