### PR TITLE
Add eregs OS stack cflinuxfs3

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -1,5 +1,6 @@
 ---
-buildpack: https://github.com/cloudfoundry/python-buildpack
+stack: cflinuxfs3
+buildpack: python_buildpack
 command: python manage.py migrate --fake-initial && gunicorn -k gevent -w 2 --bind=0.0.0.0:$PORT fec_eregs.wsgi:application
 services:
   - fec-eregs-creds # Must provide HTTP_AUTH_USER, HTTP_AUTH_PASSWORD

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -1,5 +1,6 @@
 ---
-buildpack: https://github.com/cloudfoundry/python-buildpack
+stack: cflinuxfs3
+buildpack: python_buildpack
 command: python manage.py migrate --fake-initial && gunicorn -k gevent -w 2 --bind=0.0.0.0:$PORT fec_eregs.wsgi:application
 services:
   - fec-eregs-creds # Must provide HTTP_AUTH_USER, HTTP_AUTH_PASSWORD

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -1,5 +1,6 @@
 ---
-buildpack: https://github.com/cloudfoundry/python-buildpack
+stack: cflinuxfs3
+buildpack: python_buildpack
 command: python manage.py migrate --fake-initial && gunicorn -k gevent -w 2 --bind=0.0.0.0:$PORT fec_eregs.wsgi:application
 services:
   - fec-eregs-creds # Must provide HTTP_AUTH_USER, HTTP_AUTH_PASSWORD


### PR DESCRIPTION
## Summary (required)

1.  In **`dev/stage/prod`** manifest file, add `stack` with the latest OS `cflinuxfs3`.

- Resolves #431 

_Include a summary of proposed changes._

1. manifest_dev.yml
2. manifest_prod.yml
3. manifest_stage.yml

## How to test the changes
- checkout the branch `feature/add-stack-cflinuxfs3-to-manifest-files`
- In tasks.py, under DEPLOY_RULES : https://github.com/fecgov/openFEC/blob/develop/tasks.py#L143
   add a rule to deploy the `feature/add-stack-cflinuxfs3-to-manifest-files` branch to `dev` space
   Example :  ('dev', lambda _, branch: branch == 'feature/add-stack-cflinuxfs3-to-manifest-files'),
- commit and push the changes.this will trigger a circle build
- wait until the circleci builds successfully
- open a terminal window and login to CF `dev` space 
- run `cf app eregs` command to check the `eregs` app **`stack`**, which should be now**`cflinuxfs3`** (screenshot attached below)
- In a browser, open the `dev` eregs url  : `https://fec-dev-eregs.app.cloud.gov/regulations/` and navigate through the regulations and make sure no errors.
-run this command `cf logs eregs` in a CF terminal and make sure there are no errors.
![screen shot 2019-03-07 at 4 37 25 pm](https://user-images.githubusercontent.com/11650355/53991038-afad9800-40f7-11e9-974b-a40d25e8a5f4.png)
