### PR TITLE
Update gunicorn to 19.10.0, fix failing build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ regulations==8.4.2
 cfenv==0.5.3
 dj-database-url==0.4.2
 django-overextends==0.4.3
-gunicorn==19.7.1
+gunicorn==19.10.0
 whitenoise==3.3.1
 invoke==0.22.0
 GitPython==2.1.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ django-overextends==0.4.3
 gunicorn==19.10.0
 whitenoise==3.3.1
 invoke==0.22.0
-GitPython==2.1.8
+GitPython==2.1.15
 gevent==1.2.2
 
 -e eregs_extensions/


### PR DESCRIPTION
## Summary (required)

- Resolves #466
- Resolves #468 

Update gunicorn to `19.10.0`. See https://snyk.io/vuln/SNYK-PYTHON-GUNICORN-541164
Update `GitPython` to 2.1.15 due to breaking change in `gitdb2` (see https://github.com/gitpython-developers/GitPython/issues/983)

## How to test the changes locally

- Gunicorn is only used in production, so you need to deploy to `dev` to test

## Impacted areas of the application
List general components of the application that this PR will affect:

-  More info about gunicorn: https://gunicorn.org/
- See https://github.com/fecgov/fec-eregs/blob/develop/manifest_prod.yml
