### PR TITLE
Switch eregs bind to fec-eregs-db-rdn

### DIFF
--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -4,7 +4,7 @@ buildpack: python_buildpack
 command: python manage.py migrate --fake-initial && gunicorn -k gevent -w 2 --bind=0.0.0.0:$PORT fec_eregs.wsgi:application
 services:
   - fec-eregs-creds # Must provide HTTP_AUTH_USER, HTTP_AUTH_PASSWORD
-  - fec-eregs-db
+  - fec-eregs-db-rdn
   - fec-creds-prod
 env:
   DJANGO_SETTINGS_MODULE: fec_eregs.settings.prod

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -4,7 +4,7 @@ buildpack: python_buildpack
 command: python manage.py migrate --fake-initial && gunicorn -k gevent -w 2 --bind=0.0.0.0:$PORT fec_eregs.wsgi:application
 services:
   - fec-eregs-creds # Must provide HTTP_AUTH_USER, HTTP_AUTH_PASSWORD
-  - fec-eregs-db
+  - fec-eregs-db-rdn
   - fec-creds-stage
 env:
   DJANGO_SETTINGS_MODULE: fec_eregs.settings.prod


### PR DESCRIPTION
Ref: [https://github.com/fecgov/fec-eregs/issues/470](https://github.com/fecgov/fec-eregs/issues/470)
1)The new medium-psql-redundant service, named fec-eregs-db-rdn on stage and prod space has been created.
2)The data has been restored to new db.
