### PR TITLE
[fec-eregs] Enable circleci pipeline 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # Python CircleCI 2.0 configuration file
 # Check https://circleci.com/docs/2.0/language-python/ for more details
-version: 2
+version: 2.1
 jobs:
   build:
     docker:


### PR DESCRIPTION
## Summary (required)
Update the CircleCI configuration version from 2.0 to 2.1 to enable pipelines.

- Resolves #477 
- Update circleci configuration to v2.1 in circleci/config.yml file

## How to test the changes ~locally~

- update the tasks.py with the `feature/477-enable-circleci-pipeline` branch and deploy to `dev` space.

**CircleCI dashboard _without_ pipeline** : 
<img width="1266" alt="Screen Shot 2020-03-05 at 6 20 42 PM" src="https://user-images.githubusercontent.com/11650355/76034996-62ccef00-5f0e-11ea-82f6-3f2abdb7c979.png">


**CircleCI dashboard _with_ pipeline** : 
<img width="1276" alt="Screen Shot 2020-03-05 at 6 22 17 PM" src="https://user-images.githubusercontent.com/11650355/76035024-6ceeed80-5f0e-11ea-9a2f-15b78e8aab68.png">
