### PR TITLE
Upgrade jquery to 3.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1753,9 +1753,9 @@
       "dev": true
     },
     "jquery": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.4.1.tgz",
-      "integrity": "sha512-36+AdBzCL+y6qjw5Tx7HgzeGCzC81MDDgaUP8ld2zhx58HdqXGoBd+tHdrBMiyjGQs0Hxs/MLZTu/eHNJJuWPw=="
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.5.1.tgz",
+      "integrity": "sha512-XwIBPqcMn57FxfT+Go5pzySnm4KWkT1Tv7gjrpT1srtf8Weynl6R273VJ5GjkRb51IzMp5nbaPjJXMWeju2MKg=="
     },
     "js-base64": {
       "version": "2.5.2",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "Gruntfile.js",
   "dependencies": {
     "accessible-mega-menu": "git+https://github.com/noahmanger/Accessible-Mega-Menu.git",
-    "jquery": "^3.4.1"
+    "jquery": "^3.5.1"
   },
   "devDependencies": {
     "browserify": "^13.0.0",


### PR DESCRIPTION
## Summary

- Resolves #487  
_Upgrades jquery to 3.5.1 and remediates XSS vulnerabilities._

See jquery docs on what was released for 3.5.1: https://blog.jquery.com/2020/05/04/jquery-3-5-1-released-fixing-a-regression/

## Impacted areas of the application

Upgraded jQuery from 3.4.1 to 3.5.1
modified: ../package-lock.json
modified: ../package.json

## How to test

- Run inside a python 3.7.7 environment
- `pip install -r requirements.txt`
- `pip install -r requirements_dev.txt`
- `npm i`
- `npm run build`
- `python manage.py compile_frontend` (if you receive an error about node-gyp python version here, update your npm by running `npm install -g npm`)
- `python manage.py runserver`
- Spot check things using jquery such as mega menu and glossary

____
