### PR TITLE
[MERGE WITH GITFLOW] Hotfix to fix the build errors caused by the python runtime version.

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.x
+python-3.7.7


### PR DESCRIPTION
Pin python v3.7.7. pip builds are failing with latest 3.7.x