### PR TITLE
Update cf cli to version 7

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,7 +58,7 @@ jobs:
           command: |
             mkdir -p $HOME/bin
             export PATH=$HOME/bin:$PATH
-            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=6.34.0" | tar xzv -C $HOME/bin
+            curl -L "https://cli.run.pivotal.io/stable?release=linux64-binary&version=7.1.0" | tar xzv -C $HOME/bin
             cf install-plugin autopilot -f -r CF-Community
 
       - deploy:

--- a/tasks.py
+++ b/tasks.py
@@ -1,10 +1,10 @@
 import os
 import json
-
 import git
-from invoke import task
-
 import cfenv
+import sys
+
+from invoke import task
 
 env = cfenv.AppEnv()
 
@@ -80,12 +80,11 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False):
     if space is None:
         return
 
-    # Set api
-    api = 'https://api.fr.cloud.gov'
-    ctx.run('cf api {0}'.format(api), echo=True)
-
-    # Log in if necessary
     if login == 'True':
+        # Set api
+        api = 'https://api.fr.cloud.gov'
+        ctx.run('cf api {0}'.format(api), echo=True)
+        # Authorize
         login_command = 'cf auth "$FEC_CF_USERNAME_{0}" "$FEC_CF_PASSWORD_{0}"'.format(space.upper())
         ctx.run(login_command, echo=True)
 
@@ -100,3 +99,6 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False):
     deployed = ctx.run('cf app eregs', echo=True, warn=True)
     cmd = 'zero-downtime-push' if deployed.ok else 'push'
     ctx.run('cf {0} eregs -f manifest_{1}.yml'.format(cmd, space), echo=True)
+
+    # Needed for CircleCI
+    return sys.exit(0)


### PR DESCRIPTION
## Summary (required)

Resolves #534 

**Deploy task changes:**

- With cf cli version 7, `cf api <endpoint>` logs you out - this is a known issue: https://github.com/cloudfoundry/cli/issues/2075. Only set the endpoint if `deploy` task `--login True` (used for CircleCI)
- Cf cli doesn't exit with code 0 anymore, so I had to add it. (not sure where this is documented but you can read between the lines here: https://circleci.com/docs/2.0/configuration-reference/#the-when-attribute)


## Impacted areas of the application

List general components of the application that this PR will affect:

-  Deploys

## Examples

- Example build: https://app.circleci.com/pipelines/github/fecgov/fec-eregs/142/workflows/713ccba4-11e3-41f1-bfed-760c0517c05d/jobs/452

## Reviewers
- One approval required

## How to test

**Through CircleCI**
- Make your own copy of this branch (please don't commit to this branch)
- Modify deploy task to deploy to a space of your choice
- Push to Github, make sure build works

**Locally:**
- Install cf cli version [following this guide](https://github.com/cloudfoundry/cli/wiki/Version-Switching-Guide) or:
```
# Install cf-cli@7. Complete commands
brew install cf-cli@7

# If you run across an error like this: Error: No such keg: /usr/local/Cellar/cf-cli@6, make sure you install cf-cli version 6 with brew
brew install cf-cli@6
 
# Unlink cf-cli version 6 and link cf-cli version 7
brew unlink cf-cli@6 && brew unlink cf-cli@7 && brew link cf-cli@7 && cf version
```
- Do a manual deploy with `invoke deploy --space dev`