### PR TITLE
Add internal app route, add network policy to deploy script

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -6,6 +6,7 @@ applications:
     disk_quota: 1G
     routes:
       - route: fec-dev-eregs.app.cloud.gov
+      - route: fec-dev-eregs.apps.internal
     stack: cflinuxfs3
     buildpacks:
       - python_buildpack

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: eregs
-    instances: 1
+    instances: 2
     memory: 1GB
     disk_quota: 1G
     routes:

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -6,6 +6,7 @@ applications:
     disk_quota: 1G
     routes:
       - route: fec-prod-eregs.app.cloud.gov
+      - route: fec-prod-eregs.apps.internal
     stack: cflinuxfs3
     buildpacks:
       - python_buildpack

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -6,6 +6,7 @@ applications:
     disk_quota: 1G
     routes:
       - route: fec-stage-eregs.app.cloud.gov
+      - route: fec-stage-eregs.apps.internal
     stack: cflinuxfs3
     buildpacks:
       - python_buildpack

--- a/tasks.py
+++ b/tasks.py
@@ -124,6 +124,20 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False):
         print("Check logs for more detail.")
         return sys.exit(1)
 
+    # Allow proxy to connect to eregs via internal route
+    add_network_policy = ctx.run('cf add-network-policy proxy eregs'.format(cmd, space),
+        echo=True,
+        warn=True
+    )
+    if not add_network_policy.ok:
+        print(
+            "Unable to add network policy. Make sure the proxy app is deployed.\n"
+            "For more information, check logs."
+        )
+
+        # Fail the build because eregs will be down until the proxy can connect
+        return sys.exit(1)
+
     print("\nA new version of your application 'eregs' has been successfully pushed!")
     ctx.run('cf apps', echo=True, warn=True)
 


### PR DESCRIPTION
Resolves https://github.com/fecgov/fec-accounts/issues/326

Part of https://github.com/fecgov/fec-accounts/issues/325

- Add internal route to fec-eregs app
- add network policy to deploy script
- increase instances to 2 in prod for [production best practices](https://cloud.gov/docs/management/production-ready/)

![Screen Shot 2020-11-20 at 12.04.32 PM.png](https://images.zenhubusercontent.com/59a579f28f62dc7798c47359/c8d62123-44e6-4a75-877b-b27b6dadbbbf)

## Reviewers
At least two reviewers, please

## How to test
- Make a copy of this branch, deploy to `dev` space
- Check that internal route exists
- Check prod manifest to see that it has 2 instances
- Check that proxy can still connect by going to https://dev.fec.gov/regulations/
- Check for network policies with `cf network-policies`

Test a failed build:
- Delete the proxy app in `dev` space
- Redeploy eregs and see that the build fails with an error message that makes sense
- Add the proxy app back by rebuilding `develop` branch of proxy in Circle
- Rebuild your eregs application to make sure the build now passes