### PR TITLE
Remove public app route

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -5,7 +5,6 @@ applications:
     memory: 512M
     disk_quota: 1G
     routes:
-      - route: fec-dev-eregs.app.cloud.gov
       - route: fec-dev-eregs.apps.internal
     stack: cflinuxfs3
     buildpacks:

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -6,6 +6,7 @@ applications:
     disk_quota: 1G
     routes:
       - route: fec-dev-eregs.app.cloud.gov
+      - route: fec-dev-eregs.apps.internal
     stack: cflinuxfs3
     buildpacks:
       - python_buildpack

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -5,7 +5,6 @@ applications:
     memory: 1GB
     disk_quota: 1G
     routes:
-      - route: fec-prod-eregs.app.cloud.gov
       - route: fec-prod-eregs.apps.internal
     stack: cflinuxfs3
     buildpacks:

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -1,7 +1,7 @@
 ---
 applications:
   - name: eregs
-    instances: 1
+    instances: 2
     memory: 1GB
     disk_quota: 1G
     routes:

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -6,6 +6,7 @@ applications:
     disk_quota: 1G
     routes:
       - route: fec-prod-eregs.app.cloud.gov
+      - route: fec-prod-eregs.apps.internal
     stack: cflinuxfs3
     buildpacks:
       - python_buildpack

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -6,6 +6,7 @@ applications:
     disk_quota: 1G
     routes:
       - route: fec-stage-eregs.app.cloud.gov
+      - route: fec-stage-eregs.apps.internal
     stack: cflinuxfs3
     buildpacks:
       - python_buildpack

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -5,7 +5,6 @@ applications:
     memory: 512M
     disk_quota: 1G
     routes:
-      - route: fec-stage-eregs.app.cloud.gov
       - route: fec-stage-eregs.apps.internal
     stack: cflinuxfs3
     buildpacks:

--- a/tasks.py
+++ b/tasks.py
@@ -124,6 +124,20 @@ def deploy(ctx, space=None, branch=None, login=None, yes=False):
         print("Check logs for more detail.")
         return sys.exit(1)
 
+    # Allow proxy to connect to eregs via internal route
+    add_network_policy = ctx.run('cf add-network-policy proxy eregs'.format(cmd, space),
+        echo=True,
+        warn=True
+    )
+    if not add_network_policy.ok:
+        print(
+            "Unable to add network policy. Make sure the proxy app is deployed.\n"
+            "For more information, check logs."
+        )
+
+        # Fail the build because eregs will be down until the proxy is can connect
+        return sys.exit(1)
+
     print("\nA new version of your application 'eregs' has been successfully pushed!")
     ctx.run('cf apps', echo=True, warn=True)
 


### PR DESCRIPTION
Partial resolution https://github.com/fecgov/fec-accounts/issues/329
Resolves https://github.com/fecgov/fec-eregs/issues/500

Part of https://github.com/fecgov/fec-accounts/issues/325

- Remove public eregs route
- Note that we'll need to manually remove the routes after deployment due to the [additive-only](https://github.com/cloudfoundry/cloud_controller_ng/issues/1866) nature of deploying with manifests. Example: `cf unmap-route eregs app.cloud.gov --hostname fec-dev-eregs`

![Screen Shot 2020-11-20 at 12.09.49 PM.png](https://images.zenhubusercontent.com/59a579f28f62dc7798c47359/036e5790-b45d-4d75-ae87-d5625df64c74)


## How to test

- Manually deploy this branch
- Run `cf unmap-route eregs app.cloud.gov --hostname fec-dev-eregs` (A cf cli quirk is that manifest changes with rolling deployments are additive-only, but it will only need to be done once per environment. Part of completion criteria here: https://github.com/fecgov/fec-accounts/issues/329)
- Go to old public app URL (ie, fec-dev-eregs.app.cloud.gov and get redirected to CDN route (dev.fec.gov/regulations)
- Go to dev.fec.gov/regulations and make sure it works
- Do a `cf apps` command and see that only the `apps.internal` route remains for the eregs app