### PR TITLE
Remove eregs public route

### DIFF
--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -5,7 +5,6 @@ applications:
     memory: 512M
     disk_quota: 1G
     routes:
-      - route: fec-dev-eregs.app.cloud.gov
       - route: fec-dev-eregs.apps.internal
     stack: cflinuxfs3
     buildpacks:

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -5,7 +5,6 @@ applications:
     memory: 1GB
     disk_quota: 1G
     routes:
-      - route: fec-prod-eregs.app.cloud.gov
       - route: fec-prod-eregs.apps.internal
     stack: cflinuxfs3
     buildpacks:

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -5,7 +5,6 @@ applications:
     memory: 512M
     disk_quota: 1G
     routes:
-      - route: fec-stage-eregs.app.cloud.gov
       - route: fec-stage-eregs.apps.internal
     stack: cflinuxfs3
     buildpacks:


### PR DESCRIPTION
Resolves #https://github.com/fecgov/fec-accounts/issues/329

At Least two approval required.

## How to test

- Manually deploy this branch to `dev`
- Go to old public app URL (ie, fec-dev-eregs.app.cloud.gov and get redirected to CDN route (dev.fec.gov)
- Go to dev.fec.gov and make sure it works
- In terminal,  run `curl -I "https://fec-dev-eregs.app.cloud.gov"` to see the location is now redirected to CDN route (dev.fec.gov)
- Do a `cf apps` command and see that only the `apps.internal` route remains for the `eregs` app