### PR TITLE
Bump crypto package

### DIFF
--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -18,7 +18,7 @@ cffi==1.11.5
 chardet==3.0.4
 click==6.7
 coloredlogs==9.0
-cryptography==2.2.2
+cryptography==3.2
 decorator==4.2.1
 dj-database-url==0.4.2
 Django==1.11.11


### PR DESCRIPTION
### Summary
Replaces  https://github.com/fecgov/fec-eregs/pull/538. Updates cryptography package opened by dependabot.

### How to test
- check out branch
- parse regs