### PR TITLE
bump lodash version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1944,9 +1944,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "lodash.memoize": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "browserify": "^13.0.0",
+    "lodash": "4.17.19",
     "glossary-panel": "1.0.0",
     "grunt": "^1.1.0",
     "grunt-cli": "^1.2.0",


### PR DESCRIPTION
### Summary
Replacement of dependabot PR #515 

### How to test
@rfultz: my solution was to manually add lodash as a devDependency and npm i. Can you focus your portion of the review on the correctness of this approach (I assumed just adding to package-lock.json would mean anyone deleting and reinstalling to create a new package-lock could inadvertently roll back the lodash version)

@pkfec @fec-jli: either or both of you could review. 
- check out branch
- `snyk test --file=package.json` and `snyk test --file=package-lock.json`
- run local ergs and try parsing (both worked for me and the local api formatting was fine)