### PR TITLE
Pin urllib3 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ regcore==4.2.0
 enum34==1.1.6
 futures==3.1.1
 requests==2.23.0
+urllib3==1.25.11 # pin for compatibility with requests
 boto3==1.5.13
 celery==4.1.0
 requests-toolbelt==0.8.0


### PR DESCRIPTION
### Summary
resolves #555 by pinning urllib3 version.

### How to test
Verify that the error message no longer appears in circle.
`ERROR: requests 2.23.0 has requirement urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1, but you'll have urllib3 1.26.0 which is incompatible.
`