### PR TITLE
Pin dependencies

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,3 +5,5 @@ requests[security]
 ipdb==0.10.3
 ipython>=6.0,<7.0
 regparser==4.3.1
+django-rq==2.1.0 # required by regparser, pin django compatibility
+djangorestframework==3.11.2 # required by regparser, pin django compatibility


### PR DESCRIPTION
Resolves #541 

### How to test
@pkfec @fec-jli , I deployed to dev to verify this works, but probably good for you to test this way as well. Otherwise, just verify nothing looks off to you (I pinned in the requirements_dev.txt because that's where regparser is.

- make new pyenv 3.7.9 virtualenv
- pip install {requirements.txt, requirements_test.txt, requirements_dev.txt} (it's the dev that introduced the errors before).
- To see that no more dependency error exists for django-related packages, you can pip install pipdeptree then run "pipdeptree" and these warnings should be resolved