### PR TITLE
Feature/566 trailing slashes in nav

### DIFF
--- a/fec_eregs/static/fec_eregs/js/templates/nav-about.hbs
+++ b/fec_eregs/static/fec_eregs/js/templates/nav-about.hbs
@@ -7,8 +7,8 @@
         </div>
         <div class="usa-width-one-half mega__intro">
           <ul class="usa-width-one-third">
-           <li class="mega__item"><a href="/updates">News and announcements</a></li>
-           <li class="mega__item"><a href="/meetings">Commission meetings</a></li>
+           <li class="mega__item"><a href="/updates/">News and announcements</a></li>
+           <li class="mega__item"><a href="/meetings/">Commission meetings</a></li>
            <li class="mega__item"><a href="/about/mission-and-history/">Mission and history</a></li>
           </ul>
           <ul class="usa-width-one-third">
@@ -18,7 +18,7 @@
            </ul>
            <ul class="usa-width-one-third">
             <li class="mega__item"><a href="/about/#working-with-the-fec">Working with the FEC</a></li>
-            <li class="mega__item"><a href="/contact-us">Contact</a></li>
+            <li class="mega__item"><a href="/contact-us/">Contact</a></li>
           </ul>
         </div>
       </div>

--- a/fec_eregs/static/fec_eregs/js/templates/nav-data.hbs
+++ b/fec_eregs/static/fec_eregs/js/templates/nav-data.hbs
@@ -3,26 +3,26 @@
     <div class="mega__inner">
       <div class="row">
         <div class="usa-width-one-fourth">
-          <h2 class="mega-heading__title icon-heading--data-flag-circle--primary"><a href="/data">Explore all data</a></h2>
+          <h2 class="mega-heading__title icon-heading--data-flag-circle--primary"><a href="/data/">Explore all data</a></h2>
         </div>
         <div class="usa-width-one-third mega__intro">
           <ul class="t-sans list--2-columns u-padding--top">
-            <li class="mega__item"><a href="/data/browse-data?tab=raising">Raising</a></li>
-            <li class="mega__item"><a href="/data/browse-data?tab=spending">Spending</a></li>
-            <li class="mega__item"><a href="/data/browse-data?tab=loans-debts">Loans and debts</a></li>
-            <li class="mega__item"><a href="/data/browse-data?tab=filings">Filings and reports</a></li>
-            <li class="mega__item"><a href="/data/browse-data?tab=candidates">Candidates</a></li>
-            <li class="mega__item"><a href="/data/browse-data?tab=committees">Committees</a></li>
-            <li class="mega__item"><a href="/data/browse-data?tab=bulk-data">Bulk data</a></li>
+            <li class="mega__item"><a href="/data/browse-data/?tab=raising">Raising</a></li>
+            <li class="mega__item"><a href="/data/browse-data/?tab=spending">Spending</a></li>
+            <li class="mega__item"><a href="/data/browse-data/?tab=loans-debts">Loans and debts</a></li>
+            <li class="mega__item"><a href="/data/browse-data/?tab=filings">Filings and reports</a></li>
+            <li class="mega__item"><a href="/data/browse-data/?tab=candidates">Candidates</a></li>
+            <li class="mega__item"><a href="/data/browse-data/?tab=committees">Committees</a></li>
+            <li class="mega__item"><a href="/data/browse-data/?tab=bulk-data">Bulk data</a></li>
             <li class="mega__item"><a href="/data/browse-data/?tab=historical">Historical statistics</a></li>
           </ul>
         </div>
         <div class="usa-width-one-third u-padding--left">
           <div class="icon-heading icon-heading--person-location-circle">
-            <p class="t-sans t-small icon-heading__text"><a href="/data/elections">Find elections. Search by state or ZIP code</a></p>
+            <p class="t-sans t-small icon-heading__text"><a href="/data/elections/">Find elections. Search by state or ZIP code</a></p>
           </div>
           <div class="icon-heading icon-heading--individual-contributions-circle">
-            <p class="t-sans t-small icon-heading__text"> <a href="/data/receipts/individual-contributions">Look up contributions from specific individuals</a></p>
+            <p class="t-sans t-small icon-heading__text"> <a href="/data/receipts/individual-contributions/">Look up contributions from specific individuals</a></p>
           </div>
         </div>
       </div>

--- a/fec_eregs/static/fec_eregs/js/templates/nav-help.hbs
+++ b/fec_eregs/static/fec_eregs/js/templates/nav-help.hbs
@@ -7,9 +7,9 @@
       </div>
         <div class="usa-width-one-third mega__intro">
           <ul class="t-sans list--2-columns u-padding--top">
-            <li class="mega__item"><a href="/help-candidates-and-committees/guides">Guides</a></li>
-            <li class="mega__item"><a href="/help-candidates-and-committees/forms">Forms</a></li>
-            <li class="mega__item"><a  href="/help-candidates-and-committees/dates-and-deadlines">Dates and deadlines</a></li>
+            <li class="mega__item"><a href="/help-candidates-and-committees/guides/">Guides</a></li>
+            <li class="mega__item"><a href="/help-candidates-and-committees/forms/">Forms</a></li>
+            <li class="mega__item"><a  href="/help-candidates-and-committees/dates-and-deadlines/">Dates and deadlines</a></li>
             <li class="mega__item"><a  href="https://transition.fec.gov/info/outreach.shtml">Trainings</a></li>
           </ul>
         </div>

--- a/fec_eregs/static/fec_eregs/js/templates/nav-legal.hbs
+++ b/fec_eregs/static/fec_eregs/js/templates/nav-legal.hbs
@@ -3,16 +3,16 @@
     <div class="mega__inner">
       <div class="row">
         <div class="usa-width-one-fourth">
-          <h2 class="mega-heading__title icon-heading--data-flag-circle--primary"><a href="/legal-resources">Explore all legal resources</a></h2>
+          <h2 class="mega-heading__title icon-heading--data-flag-circle--primary"><a href="/legal-resources/">Explore all legal resources</a></h2>
         </div>
         <div class="usa-width-one-third mega__intro">
           <ul class="t-sans list--2-columns u-padding--top">
-            <li class="mega__item"><a href="/data/legal/advisory-opinions">Advisory opinions</a></li>
-            <li class="mega__item"><a href="/legal-resources/enforcement">Enforcement</a></li>
-            <li class="mega__item"><a href="/data/legal/statutes">Statutes</a></li>
-            <li class="mega__item"><a href="/legal-resources/legislation">Legislation</a></li>
-            <li class="mega__item"><a href="/legal-resources/regulations">Regulations</a></li>
-            <li class="mega__item"><a href="/legal-resources/court-cases">Court cases</a></li>
+            <li class="mega__item"><a href="/data/legal/advisory-opinions/">Advisory opinions</a></li>
+            <li class="mega__item"><a href="/legal-resources/enforcement/">Enforcement</a></li>
+            <li class="mega__item"><a href="/data/legal/statutes/">Statutes</a></li>
+            <li class="mega__item"><a href="/legal-resources/legislation/">Legislation</a></li>
+            <li class="mega__item"><a href="/legal-resources/regulations/">Regulations</a></li>
+            <li class="mega__item"><a href="/legal-resources/court-cases/">Court cases</a></li>
             <li class="mega__item"><a href="https://transition.fec.gov/law/policy.shtml">Policy and other guidance</a></li>
           </ul>
         </div>

--- a/fec_eregs/templates/regulations/chrome.html
+++ b/fec_eregs/templates/regulations/chrome.html
@@ -12,10 +12,10 @@ Empty the sub-head, we use the breadcrumbs in main-header.html
 {% block drawer-toc %}
 <div class="toc-head">
   <a href="#" id="panel-link" class="toc-toggle panel-slide">
-    <img id="open-active" src="{%static "regulations/img/open-caret.svg" %}" class="drawer-toggle-icon" alt="Open navigation drawer" />
-    <img id="open" src="{%static "regulations/img/open-caret-blue.svg" %}" class="drawer-toggle-icon" alt="Open navigation drawer" />
-    <img id="close" src="{%static "regulations/img/close-caret-blue.svg" %}" class="drawer-toggle-icon" alt="Close navigation drawer"/>
-    <img id="close-active" src="{%static "regulations/img/close-caret.svg" %}" class="drawer-toggle-icon" alt="Close navigation drawer"/>
+    <img id="open-active" src="{% static "regulations/img/open-caret.svg" %}" class="drawer-toggle-icon" alt="Open navigation drawer" />
+    <img id="open" src="{% static "regulations/img/open-caret-blue.svg" %}" class="drawer-toggle-icon" alt="Open navigation drawer" />
+    <img id="close" src="{% static "regulations/img/close-caret-blue.svg" %}" class="drawer-toggle-icon" alt="Close navigation drawer"/>
+    <img id="close-active" src="{% static "regulations/img/close-caret.svg" %}" class="drawer-toggle-icon" alt="Close navigation drawer"/>
   </a>
 </div> <!-- /toc-head-->
 

--- a/fec_eregs/templates/regulations/logo-large.html
+++ b/fec_eregs/templates/regulations/logo-large.html
@@ -2,4 +2,4 @@
 Large image which appears on the generic 404 page
 {% endcomment %}
 {% load static from staticfiles %}
-<img src="{%static "fec_eregs/img/fec-logo.png" %}" class="logo" alt="Federal Elections Commission" width="151px">
+<img src="{% static "fec_eregs/img/fec-logo.png" %}" class="logo" alt="Federal Election Commission" width="151px">

--- a/fec_eregs/templates/regulations/logo.html
+++ b/fec_eregs/templates/regulations/logo.html
@@ -1,4 +1,4 @@
 {% load staticfiles %}
-<a href="http://www.fec.gov"><img class="logo" alt="Federal Elections Commission"
+<a href="https://www.fec.gov/"><img class="logo" alt="Federal Election Commission"
                                   style="margin: 0.25em; height: 45px; width: 45px; vertical-align: middle;"
                                   src="{% static "fec_eregs/img/fec-logo.png" %}" />FEC</a>

--- a/fec_eregs/templates/regulations/main-header.html
+++ b/fec_eregs/templates/regulations/main-header.html
@@ -36,12 +36,12 @@
       <ul class="site-nav__panel site-nav__panel--main">
         <li><h2 class="site-nav__title u-under-lg-only">Menu</h2></li>
         <li class="site-nav__item u-under-lg-only">
-          <a class="site-nav__link" href="{{ FEC_CMS_URL }}" rel="home">
+          <a class="site-nav__link" href="{{ FEC_CMS_URL }}/" rel="home">
             <span class="site-nav__link__title">Home</span>
           </a>
         </li>
         <li class="site-nav__item" data-submenu="data">
-          <a href="{{ FEC_WEB_URL }}" class="site-nav__link">
+          <a href="{{ FEC_WEB_URL }}/" class="site-nav__link">
             <span class="site-nav__link__title">Campaign finance data</span>
           </a>
         </li>
@@ -51,18 +51,18 @@
           </a>
         </li>
         <li class="site-nav__item" data-submenu="legal">
-          <a href="{{ FEC_CMS_URL }}/legal-resources" class="site-nav__link is-parent">
+          <a href="{{ FEC_CMS_URL }}/legal-resources/" class="site-nav__link is-parent">
             <span class="site-nav__link__title">Legal resources</span>
           </a>
         </li>
         <li class="site-nav__item--secondary" data-submenu="about">
-          <a href="{{ FEC_CMS_URL }}/about" class="site-nav__link">
+          <a href="{{ FEC_CMS_URL }}/about/" class="site-nav__link">
             <span class="site-nav__link__title">About</span>
           </a>
         </li>
 
         <li class="site-nav__item utility-nav__item u-under-lg-only">
-          <a href="{{ FEC_CMS_URL }}/calendar" class="site-nav__link">Calendar</a>
+          <a href="{{ FEC_CMS_URL }}/calendar/" class="site-nav__link">Calendar</a>
         </li>
         <li class="site-nav__item site-nav__link utility-nav__item u-under-lg-only">
           <form accept-charset="UTF-8" action="{{ cms_url }}/search" class="combo combo--search--mini" method="get" role="search">
@@ -85,7 +85,7 @@
       </ul>
     </div>
     <button for="nav-toggle" class="js-nav-toggle site-nav__button" aria-controls="site-menu">Menu</button>
-    <a title="Home" href="{{ FEC_CMS_URL }}" class="site-title"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
+    <a title="Home" href="{{ FEC_CMS_URL }}/" class="site-title"><span class="u-visually-hidden">Federal Election Commission | United States of America</span></a>
   </nav>
   <div class="page-header page-header--primary">
     <ul class="breadcrumbs">

--- a/fec_eregs/templates/regulations/org-title.html
+++ b/fec_eregs/templates/regulations/org-title.html
@@ -1,1 +1,1 @@
-<a href="http://www.fec.gov">Federal Elections Commission</a>
+<a href="https://www.fec.gov/">Federal Election Commission</a>

--- a/manifest_dev.yml
+++ b/manifest_dev.yml
@@ -18,7 +18,7 @@ applications:
       FEC_API_VERSION: v1
       SCRIPT_NAME: /regulations
       WEB_CONCURRENCY: 4
-      FEC_API_URL: https://fec-dev-api.app.cloud.gov
-      FEC_CMS_URL: "https://fec-dev-proxy.app.cloud.gov"
+      FEC_API_URL: "https://fec-dev-api.app.cloud.gov"
+      FEC_CMS_URL: "https://dev.fec.gov"
       FEC_WEB_URL: "/data"
       APP_NAME: fec | dev | eregs

--- a/manifest_prod.yml
+++ b/manifest_prod.yml
@@ -18,7 +18,7 @@ applications:
       FEC_API_VERSION: v1
       SCRIPT_NAME: /regulations
       WEB_CONCURRENCY: 4
-      FEC_API_URL: https://api.open.fec.gov
+      FEC_API_URL: "https://api.open.fec.gov"
       FEC_CMS_URL: "https://www.fec.gov"
       FEC_WEB_URL: "/data"
       APP_NAME: fec-prod-eregs

--- a/manifest_stage.yml
+++ b/manifest_stage.yml
@@ -18,7 +18,7 @@ applications:
       FEC_API_VERSION: v1
       SCRIPT_NAME: /regulations
       WEB_CONCURRENCY: 4
-      FEC_API_URL: https://api-stage.open.fec.gov
-      FEC_CMS_URL: "https://fec-stage-proxy.app.cloud.gov"
+      FEC_API_URL: "https://api-stage.open.fec.gov"
+      FEC_CMS_URL: "https://stage.fec.gov"
       FEC_WEB_URL: "/data"
       APP_NAME: fec-stage-eregs


### PR DESCRIPTION
## Summary

Resolves #566 

1. Added trailing slashes to URLs where obvious (nav-*.hbs and main-header.html)
1. Followed trail to check FEC_WEB_URL and FEC_CMS_URL inside manifest_*.yml
   - updated the subdomain
   - quoted those values for consistency
1. Scanned site for any other instance of`href="`
   - added trailing slashes to links to .gov
   - updated protocol to https for links to .gov
   - Fixed named of FEC the few places it was wrong
   - Followed trail of `{%static` and updated/linted them to `{% static`

## Screenshots
No visual changes

## Reviewers
Not sure who all should review this. I'm not familiar enough with e-regs yet

## How to test
- I'm curious about this myself!
- These changes shouldn't change anything about the build or visual content
