### PR TITLE
Upgrade lxml 4.2.1-4.6.2 for parsing

### DIFF
--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -53,7 +53,7 @@ jmespath==0.9.3
 json-delta==2.0
 jsonschema==2.5.1
 kombu==4.1.0
-lxml==4.2.1
+lxml==4.6.2
 marshmallow==2.19.2
 networkx==2.1
 newrelic==2.100.0.84


### PR DESCRIPTION
Issue: [https://github.com/fecgov/fec-eregs/issues/568](https://github.com/fecgov/fec-eregs/issues/568)

 lxml is used for parsing regulation, after upgrade, make sure parsing works as expected. 

### How to test
1) check out branch
2) setup eregs api local, make sure no issue
3) setup eregs-parsing terminal, make sure parsing as expected.
before lxml upgrade, run: 
```snyk test --file=requirements-parsing.txt --package-manager=pip```
will get 27 issues
<img width="710" alt="Screen Shot 2021-02-23 at 12 28 07 PM" src="https://user-images.githubusercontent.com/24395751/108906203-9ce74300-75ee-11eb-854e-e9bea7a15ce3.png">

after lxml (v4.2.1—>v4.6.2), will get 24 issues, lxml issue gone.
<img width="722" alt="Screen Shot 2021-02-23 at 12 28 36 PM" src="https://user-images.githubusercontent.com/24395751/108906266-b12b4000-75ee-11eb-9684-f60d44e368f6.png">


