### PR TITLE
Update glossary term Admin termination

### DIFF
--- a/fec_eregs/static/fec_eregs/js/data/terms.json
+++ b/fec_eregs/static/fec_eregs/js/data/terms.json
@@ -8,7 +8,7 @@
     "definition": "For party committees, rent, utilities, office equipment, office supplies, routine building maintenance and other operating costs not attributable to a specific candidate."
   },
     {
-    "term": "Adminstrative termination",
+    "term": "Administrative termination",
     "definition": "Administrative termination is the action taken by the Commission to terminate the reporting obligations of political committees that appear to be inactive in accordance with 52 U.S.C.<a href=\"https://www.govinfo.gov/link/uscode/52/30103\">30103(d)(2)</a> and <a href=\"https://www.fec.gov/regulations/102-4/CURRENT#102-4\">11 CFR 102.4</a>. Administrative termination does not relieve a committee of any legal responsibility for the payment of any outstanding debt or obligations."
   },
   {

--- a/fec_eregs/static/fec_eregs/js/data/terms.json
+++ b/fec_eregs/static/fec_eregs/js/data/terms.json
@@ -7,6 +7,10 @@
     "term": "Administrative expense",
     "definition": "For party committees, rent, utilities, office equipment, office supplies, routine building maintenance and other operating costs not attributable to a specific candidate."
   },
+    {
+    "term": "Adminstrative termination",
+    "definition": "Administrative termination is the action taken by the Commission to terminate the reporting obligations of political committees that appear to be inactive in accordance with 52 U.S.C.<a href=\" https://www.govinfo.gov/link/uscode/52/30103\">30103(d)(2)</a> and <a href=\"https://www.fec.gov/regulations/102-4/CURRENT#102-4\">11 CFR 102.4</a>. Administrative termination does not relieve a committee of any legal responsibility for the payment of any outstanding debt or obligations."
+  },
   {
     "term": "Advance",
     "definition": "The payment by an individual from his or her personal funds, including a personal credit card, for the costs incurred in providing goods or services to, or obtaining goods or services that are used by or on behalf of, a candidate or a political committee.  See <a href=\"https://www.fec.gov/regulations/116-5/CURRENT#116-5\">11 CFR 116.5</a>."

--- a/fec_eregs/static/fec_eregs/js/data/terms.json
+++ b/fec_eregs/static/fec_eregs/js/data/terms.json
@@ -9,7 +9,7 @@
   },
     {
     "term": "Adminstrative termination",
-    "definition": "Administrative termination is the action taken by the Commission to terminate the reporting obligations of political committees that appear to be inactive in accordance with 52 U.S.C.<a href=\" https://www.govinfo.gov/link/uscode/52/30103\">30103(d)(2)</a> and <a href=\"https://www.fec.gov/regulations/102-4/CURRENT#102-4\">11 CFR 102.4</a>. Administrative termination does not relieve a committee of any legal responsibility for the payment of any outstanding debt or obligations."
+    "definition": "Administrative termination is the action taken by the Commission to terminate the reporting obligations of political committees that appear to be inactive in accordance with 52 U.S.C.<a href=\"https://www.govinfo.gov/link/uscode/52/30103\">30103(d)(2)</a> and <a href=\"https://www.fec.gov/regulations/102-4/CURRENT#102-4\">11 CFR 102.4</a>. Administrative termination does not relieve a committee of any legal responsibility for the payment of any outstanding debt or obligations."
   },
   {
     "term": "Advance",


### PR DESCRIPTION
Added "administrative termination" to the glossary

Please make sure the end result looks like this:

**Administrative termination** - Administrative termination is the action taken by the Commission to terminate the reporting obligations of political committees that appear to be inactive in accordance with 52 U.S.C. 30103(d)(2) and 11 CFR 102.4. Administrative termination does not relieve a committee of any legal responsibility for the payment of any outstanding debt or obligations.

And the links for the statute and regs works too. Thank you.