### PR TITLE
Update python packages requests to v2.26.0 and urllib to v1.26.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,8 @@ regcore==4.2.0
 # django, cached-property, six already covered
 enum34==1.1.6
 futures==3.1.1
-requests==2.23.0
-urllib3==1.25.11 # pin for compatibility with requests
+requests==2.26.0
+urllib3==1.26.6 # pin for compatibility with requests
 boto3==1.5.13
 celery==4.1.0
 requests-toolbelt==0.8.0


### PR DESCRIPTION
## Summary 

 Under fec-eregs/requirements.txt file:
- Update urllib3 to v1.26.6 and requests to v2.26.0 

- Resolves #613 

### Required reviewers

At Least one developer review is required


## Screenshots

on `fec-eregs/develop` branch: run `snyk test --file=requirements.txt --package-manager=pip`
on terminal log:
```
Upgrade urllib3@1.25.11 to urllib3@1.26.5 to fix
  ✗ Regular Expression Denial of Service (ReDoS) [Medium Severity][https://snyk.io/vuln/SNYK-PYTHON-URLLIB3-1533435] in urllib3@1.25.11
```

on `fec-eregs/feature/613-upgrade-urllib-requests-pkgs branch`: run `snyk test --file=requirements.txt --package-manager=pip`
on terminal log:
`NO ERROR in the terminal log regarding urllib3 pkg`

## How to test
-  checkout feature branch
- create new a new python virtualenv with v3.7.9
- run `pip install -r requirements.txt` 
- run  `snyk test --file=requirements.txt --package-manager=pip`
- follow the instructions on wiki and [parse regs on local](https://github.com/fecgov/fec-eregs/wiki/Parse-regulations-on-local), just in case
