### PR TITLE
Test django debug toolbar settings

### DIFF
--- a/fec_eregs/settings/dev.py
+++ b/fec_eregs/settings/dev.py
@@ -2,11 +2,6 @@ from .base import *
 import os
 
 DEBUG = True
-INSTALLED_APPS = INSTALLED_APPS + ['debug_toolbar',]
-
-MIDDLEWARE = [
-    'debug_toolbar.middleware.DebugToolbarMiddleware',
-]
 
 # Analytics settings
 

--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -23,7 +23,6 @@ decorator==4.2.1
 dj-database-url==0.4.2
 Django==1.11.11
 django-click==2.0.0
-django-debug-toolbar==1.9.1
 django-haystack==2.4.1
 django-js-asset==1.0.0
 django-mptt==0.8.7

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,5 +1,3 @@
-django-debug-toolbar==1.9.1
-
 # regulations-parser (for loading regs)
 requests[security]
 ipdb==0.10.3


### PR DESCRIPTION
## Summary (required)

 `django-debug-toolbar` is a dev dependency and not used in deployment. Upgrading this package is breaking other dependable packages (django, six etc...) and projects (regsite, regulations). 

Removed this outdated package for the dev and parsing requirements and parsed regs to make sure the eregs app works OK.

1. Delete django-debug-toolbar pkg from dev and parser requirements file.
2. In dev settings, remove django-debug-toolbar pkg from installed apps and middleware.

- Resolves #615 

### Required reviewers

At least one developer

## How to test

- checkout feature/test-django-debug-toolbar-settings
- follow [local-development](https://github.com/fecgov/fec-eregs#local-development) and test fec-eregs app
- follow [instructions](https://github.com/fecgov/fec-eregs/wiki/Parse-regulations-on-local) and parse regs on local env 
- run `snyk test --file=requirements_dev.txt --package-manager=pip`