### PR TITLE
upgrade-django-lts-v3.2.10

### DIFF
--- a/fec_eregs/settings/base.py
+++ b/fec_eregs/settings/base.py
@@ -56,3 +56,5 @@ FEC_WEB_URL = os.environ.get('FEC_WEB_URL', '')
 SIDEBARS = (
     'regulations.generator.sidebar.help.Help',
 )
+# Satisfies Django3.2 auto-created primary keys, set to AutoField
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/fec_eregs/templates/regulations/base.html
+++ b/fec_eregs/templates/regulations/base.html
@@ -1,5 +1,5 @@
 {% extends "regulations/base.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 {% block preload %}
 <link rel="stylesheet" href="{% static "fec_eregs/css/main.css" %}">

--- a/fec_eregs/templates/regulations/chrome.html
+++ b/fec_eregs/templates/regulations/chrome.html
@@ -1,5 +1,5 @@
 {% extends "regulations/chrome.html" %}
-{% load static from staticfiles %}
+{% load static %}
 
 
 {% comment %}

--- a/fec_eregs/templates/regulations/favicon.html
+++ b/fec_eregs/templates/regulations/favicon.html
@@ -1,5 +1,5 @@
 {% comment %}
   <link> tags, etc. which go in the header
 {% endcomment %}
-{% load static from staticfiles %}
+{% load static %}
 <link rel="shortcut icon" type="image/png" href="{%static "fec_eregs/img/favicon.png" %}"/>

--- a/fec_eregs/templates/regulations/generic_universal.html
+++ b/fec_eregs/templates/regulations/generic_universal.html
@@ -1,5 +1,5 @@
 {% extends "regulations/generic_universal.html" %}
-{% load staticfiles %}
+{% load static %}
 
 {% block body %}
 <header id="site-header" class="reg-header">

--- a/fec_eregs/templates/regulations/logo-large.html
+++ b/fec_eregs/templates/regulations/logo-large.html
@@ -1,5 +1,5 @@
 {% comment %}
 Large image which appears on the generic 404 page
 {% endcomment %}
-{% load static from staticfiles %}
+{% load static %}
 <img src="{% static "fec_eregs/img/fec-logo.png" %}" class="logo" alt="Federal Election Commission" width="151px">

--- a/fec_eregs/templates/regulations/logo.html
+++ b/fec_eregs/templates/regulations/logo.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <a href="https://www.fec.gov/"><img class="logo" alt="Federal Election Commission"
                                   style="margin: 0.25em; height: 45px; width: 45px; vertical-align: middle;"
                                   src="{% static "fec_eregs/img/fec-logo.png" %}" />FEC</a>

--- a/fec_eregs/templates/regulations/main-header.html
+++ b/fec_eregs/templates/regulations/main-header.html
@@ -1,4 +1,4 @@
-{% load static from staticfiles %}
+{% load static %}
 <div class="main-head">
   <div class="fec-disclaimer">
     <span class="disclaimer__right">

--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -64,13 +64,13 @@ psycopg2==2.7.3.2
 ptyprocess==0.5.2
 pycparser==2.18
 pyelasticsearch==1.4
-Pygments==2.2.0
+Pygments==2.7.4
 pyOpenSSL==17.5.0
 pyparsing==2.2.0
 python-constraint==1.3.1
 python-dateutil==2.7.2
 pytz==2018.3
-PyYAML==5.3
+PyYAML==5.4
 redis==3.1.0
 # regparser
 -e git+https://github.com/fecgov/regulations-parser.git@pkfec-django3-parser#egg=regparser
@@ -80,7 +80,7 @@ redis==3.1.0
 
 # regcore
 -e git+git://github.com/fecgov/regulations-core@pkfec-upgrade-django3-core#egg=regcore
-requests==2.21.0
+requests==2.25.1
 requests-cache==0.4.13
 requests-toolbelt==0.8.0
 roman==2.0.0
@@ -90,11 +90,11 @@ simplegeneric==0.8.1
 simplejson==3.13.2
 six==1.11.0
 smmap2==2.0.3
-sqlparse==0.2.4
+sqlparse==0.4.2
 stevedore==1.28.0
 traitlets==4.3.2
-urllib3==1.22
+urllib3==1.26.7
 vine==1.1.4
 wcwidth==0.1.7
-webargs==5.4.0
+webargs==5.5.3
 whitenoise==3.3.1

--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -14,20 +14,20 @@ cached-property==1.3.1
 celery==4.1.0
 certifi==2018.1.18
 cfenv==0.5.3
-cffi==1.11.5
+cffi==1.12
 chardet==3.0.4
 click==6.7
 coloredlogs==9.0
-cryptography==3.2
+cryptography==3.3.2
 decorator==4.2.1
 dj-database-url==0.4.2
-django==3.1.14
+django==3.2.10
 django-click==2.0.0
 django-haystack==3.1.1
 django-js-asset==1.0.0
 django-mptt==0.13.4
 django-rq==2.5.1
-djangorestframework==3.7.7
+djangorestframework==3.11.2
 docutils==0.14
 elasticsearch==1.9.0
 enum34==1.1.6
@@ -37,7 +37,7 @@ gitdb2==2.0.3
 GitPython==2.1.8
 gevent==1.4.0
 greenlet==0.4.16 # pinned to fix build problem (parent is gevent)
-gunicorn==19.7.1
+gunicorn==19.10.0
 humanfriendly==4.9
 idna==2.6
 inflection==0.3.1
@@ -50,7 +50,7 @@ jmespath==0.9.3
 json-delta==2.0
 jsonschema==2.5.1
 kombu==4.1.0
-lxml==4.6.2
+lxml==4.6.5
 marshmallow==2.19.2
 networkx==2.1
 newrelic==2.100.0.84
@@ -66,20 +66,20 @@ pycparser==2.18
 pyelasticsearch==1.4
 Pygments==2.7.4
 pyOpenSSL==17.5.0
-pyparsing==2.2.0
+pyparsing==2.2.1
 python-constraint==1.3.1
-python-dateutil==2.7.2
+python-dateutil==2.7.3
 pytz==2018.3
 PyYAML==5.4
 redis==3.1.0
 # regparser
--e git+https://github.com/fecgov/regulations-parser.git@pkfec-django3-parser#egg=regparser
+-e git+https://github.com/fecgov/regulations-parser.git@master#egg=regparser
 
 # regsite
--e git+git://github.com/fecgov/regulations-site@pkfec-django3-site#egg=regulations
+-e git+git://github.com/fecgov/regulations-site@master#egg=regulations
 
 # regcore
--e git+git://github.com/fecgov/regulations-core@pkfec-upgrade-django3-core#egg=regcore
+-e git+git://github.com/fecgov/regulations-core@master#egg=regcore
 requests==2.25.1
 requests-cache==0.4.13
 requests-toolbelt==0.8.0

--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -21,17 +21,16 @@ coloredlogs==9.0
 cryptography==3.2
 decorator==4.2.1
 dj-database-url==0.4.2
-Django==2.2.24
+django==3.1.14
 django-click==2.0.0
-django-haystack==2.4.1
+django-haystack==3.1.1
 django-js-asset==1.0.0
 django-mptt==0.13.4
-django-rq==1.0.1
+django-rq==2.5.1
 djangorestframework==3.7.7
 docutils==0.14
 elasticsearch==1.9.0
 enum34==1.1.6
-#-e git+git@github.com:fecgov/fec-eregs.git@ca141fd5e431805df1a70ac76d91bd9a5ac4b9#76#egg=fec_regparser&subdirectory=eregs_extensions
 furl==1.0.1
 futures==3.1.1
 gevent==1.2.2
@@ -72,21 +71,20 @@ python-constraint==1.3.1
 python-dateutil==2.7.2
 pytz==2018.3
 PyYAML==3.12
-redis==2.10.6
+redis==3.1.0
 # regparser
--e git+https://github.com/fecgov/regulations-parser.git@master#egg=regparser
+-e git+https://github.com/fecgov/regulations-parser.git@pkfec-django3-parser#egg=regparser
 
 # regsite
--e git+git://github.com/fecgov/regulations-site@master#egg=regulations
+-e git+git://github.com/fecgov/regulations-site@pkfec-django3-site#egg=regulations
 
 # regcore
--e git+git://github.com/fecgov/regulations-core@master#egg=regcore
-
+-e git+git://github.com/fecgov/regulations-core@pkfec-upgrade-django3-core#egg=regcore
 requests==2.21.0
 requests-cache==0.4.13
 requests-toolbelt==0.8.0
 roman==2.0.0
-rq==0.10.0
+rq==1.3.0
 s3transfer==0.1.13
 simplegeneric==0.8.1
 simplejson==3.13.2

--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -33,10 +33,10 @@ elasticsearch==1.9.0
 enum34==1.1.6
 furl==1.0.1
 futures==3.1.1
-gevent==1.2.2
 gitdb2==2.0.3
 GitPython==2.1.8
-greenlet==0.4.13
+gevent==1.4.0
+greenlet==0.4.16 # pinned to fix build problem (parent is gevent)
 gunicorn==19.7.1
 humanfriendly==4.9
 idna==2.6
@@ -70,7 +70,7 @@ pyparsing==2.2.0
 python-constraint==1.3.1
 python-dateutil==2.7.2
 pytz==2018.3
-PyYAML==3.12
+PyYAML==5.3
 redis==3.1.0
 # regparser
 -e git+https://github.com/fecgov/regulations-parser.git@pkfec-django3-parser#egg=regparser

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ greenlet==0.4.16 # pinned to fix build problem (parent gevent)
 -e eregs_extensions/
 
 # regparser
--e git+https://github.com/fecgov/regulations-parser.git@pkfec-django3-parser#egg=regparser
+-e git+https://github.com/fecgov/regulations-parser.git@master#egg=regparser
 
 # regsite
 -e git+git://github.com/fecgov/regulations-site@master#egg=regulations

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # regulations-core
-django==2.2.24
+django==3.1.14
 cached_property==1.3.1
 django-mptt==0.13.4
 anyjson==0.3.3
@@ -7,7 +7,7 @@ jsonschema==2.5.1
 six==1.11.0
 webargs==6.0.0
 pyelasticsearch==1.4
-django-haystack==2.4.1
+django-haystack==3.1.1
 psycopg2==2.7.3.2
 
 # regulations-site
@@ -34,7 +34,7 @@ greenlet==0.4.16 # pinned to fix build problem (parent gevent)
 -e eregs_extensions/
 
 # regparser
--e git+https://github.com/fecgov/regulations-parser.git@master#egg=regparser
+-e git+https://github.com/fecgov/regulations-parser.git@pkfec-django3-parser#egg=regparser
 
 # regsite
 -e git+git://github.com/fecgov/regulations-site@master#egg=regulations


### PR DESCRIPTION
## Summary (required)
Django LTS v2.2  extended support ends in april 2022. Snyk flagging Django LTS v2.2 as vulnerable and suggesting to upgrade Django to next LTS v3.2.10.

Restrictions to Parse regs with 3.6.x is lifted with this PR. Reg's can be parsed with python 3.7.x

_**Note: Prior to this PR, regulations were parsed with a FIXED python version 3.6.x**_ 


- Resolves #641 
- Resolves #https://github.com/fecgov/fec-epics/issues/205

(Include a summary of proposed changes and connect issue below)

1.  upgrade django to lts version 3.2.10 in fec-eregs, regulations-site, regulations-core repos
2.  upgrade other vulnerable packages to the  parser compatible  versions(able to parse regs without running into any compile or runtime errors). 
3.  parse regs with python v3.7.* 

**Django 3.2.10 upgrade highlights**:
4. Replace deprecated template tag `staticfiles` with `static` tag in regulation-site repo.
5. Set the required default context in regulation-core repo
6. Set the DEFAULT_AUTO_FIELD in regulation-parser, fec-eregs repo
7. Update the app configuration in parser:
_app name = 'regparser.web.jobs'_

### Required reviewers

Two developers are must. 

## Impacted areas of the application

Legal Resources/ Regulations

  
## How to test

**Terminal#1:** 
1. create python 3.7.12 virtualenv for fec-eregs: run `pyenv virtualenv 3.7.12 venv-eregs-3712` 
2. install the requirements.txt: run `pip install -r requirements.txt`
3. remove node_modules: run `rm -rf node_modules`
4. run `npm i` 
5. run  `npm run build`
6. run `dropdb eregs-db` if the eregs database already exist.
7. run `createdb eregs-db` (same name as defined in local_settings.py) 
 _create a new local_settings.py with the following configuration if one doesn't exist:_
```
API_BASE = 'http://localhost:8000/api/'
DATABASES = {
  'default': {
    'ENGINE': 'django.db.backends.postgresql_psycopg2',
    'NAME': 'eregs-db',
    'HOST': '127.0.0.1',
    'PORT': '5432',
  }
}
```
8. run `python manage.py migrate`
9. run `python manage.py compile_frontend`
10. run `python manage.py runserver` (leave this running)

**Terminal#2:**

1.  create python 3.7.12 virtualenv for parser: run `pyenv virtualenv 3.7.12 venv-parser-3712` 
2. install parser requirements:  run `pip install -r requirements-parsing.txt`
3. parser 2021 regs on to local db: run `python load_regs/load_fec_regs.py local`

**On terminal 2: total #45, regulations (for the year 2021) will be parsed on to your local eregs database 

**sample output:**
```
(venv-parser-3712) macadmins-mbp-5:fec-eregs pkasireddy$ python load_regs/load_fec_regs.py local
Operations to perform:
  Apply all migrations: admin, auth, contenttypes, django_rq, index, jobs, sessions
Running migrations:
  No migrations to apply.
2021-12-24 03:50:19 regparser.history.annual                 No <PARTS> in https://www.gpo.gov/fdsys/bulkdata/CFR/2021/title-11/CFR-2021-title11-vol1.xml. Assuming this volume contains all of the regs
2021-12-24 03:50:19 regparser.commands.annual_version        Getting annual version - 11 CFR 1, Year: 2021
2021-12-24 03:50:20 regparser.commands.layers                Build layers - 11 CFR 1
2021-12-24 03:50:26 regparser.commands.diffs                 Build diffs - 11 Part 1
2021-12-24 03:50:28 regparser.commands.write_to              Export output - 11 CFR 1, Destination: http://localhost:8000/api
2021-11-30 18:31:22 regparser.commands.write_to              Export output - 11 CFR 1, Destination:
2021-11-30 18:40:19 regparser.commands.write_to              Export output - 11 CFR 9039, Destination: http://localhost:8000/api
2021-12-24 03:59:54 regparser.commands.annual_version        Getting annual version - 11 CFR 9039, Year: 2021
2021-12-24 03:59:55 regparser.commands.layers                Build layers - 11 CFR 9039
2021-12-24 04:00:01 regparser.commands.diffs                 Build diffs - 11 Part 9039
2021-12-24 04:00:03 regparser.commands.write_to              Export output - 11 CFR 9039, Destination: http://localhost:8000/api

2021-11-30 18:40:17 regparser.commands.diffs                 Build diffs - 11 Part 9039
2021-11-30 18:40:19 regparser.index.entry                    Wrote .eregs_index/diff/11/9039/2021-annual-9039/2021-annual-9039
2021-11-30 18:40:19 regparser.commands.write_to              Export output - 11 CFR 9039, Destination: http://localhost:8000/api

```
** 45 regulations should show on the browser here: http://localhost:8000/** 
<img width="1399" alt="Screen Shot 2021-12-01 at 8 03 34 PM" src="https://user-images.githubusercontent.com/11650355/144339192-00f67dbb-9b1d-4816-9990-f77de3a352a3.png">



NOTE: ** I will update the fec-eregs setup/parser instructions on the wiki after this PR is merged 
