### PR TITLE
UX tweaks for MVP

### DIFF
--- a/fec_eregs/static/regulations/css/scss/module/_custom.scss
+++ b/fec_eregs/static/regulations/css/scss/module/_custom.scss
@@ -377,7 +377,7 @@ html, body, .landing-content, .search-panel {
   .supplement-section section:before,
   .footnotes li:before {
       height: $mainhead_small_height;
-      margin: -1 * $mainhead_height 0 0;
+      margin: -1 * $mainhead_small_height 0 0;
   }
 
   .reg-section .level-1 li,
@@ -403,6 +403,10 @@ div.footer-disclaimer {
 
 #site-header {
   position: static;
+}
+
+.landing-content  {
+    margin-top: 0;
 }
 
 #menu, .toc-head  {

--- a/fec_eregs/static/regulations/css/scss/module/_custom.scss
+++ b/fec_eregs/static/regulations/css/scss/module/_custom.scss
@@ -399,7 +399,8 @@ div.footer-disclaimer {
 }
 
 
-//Overriding some styled above for mobile and responsive breakpoints
+//Overriding some styles for mobile and responsive breakpoints above so regulations, toc and toggle are always fully visible 
+
 
 #site-header {
   position: static;
@@ -412,7 +413,13 @@ div.footer-disclaimer {
 #menu, .toc-head  {
    top: 179px;
   }
-  .reg-section:before {
+
+.reg-section{
+     margin-left: 20px
+  }
+
+
+.reg-section:before {
      margin: -314px 0 0;
   }
 
@@ -420,6 +427,7 @@ div.footer-disclaimer {
   #menu, .toc-head  {
    top: 229px;
   }
+
   .reg-section:before {
      margin: -2 * $mainhead_height + 40 0 0;
   }

--- a/fec_eregs/static/regulations/css/scss/module/_custom.scss
+++ b/fec_eregs/static/regulations/css/scss/module/_custom.scss
@@ -150,7 +150,7 @@ $toc-background: $neutral;
   border-bottom: none;
   border-right: none;
   height: auto;
-  left: 188px;
+  left: 200px;
   position: fixed;
   top: $mainhead_height + $subhead_height;
   transition: none;

--- a/fec_eregs/static/regulations/css/scss/module/_custom.scss
+++ b/fec_eregs/static/regulations/css/scss/module/_custom.scss
@@ -155,7 +155,8 @@ $toc-background: $neutral;
   top: $mainhead_height + $subhead_height;
   transition: none;
   width: auto;
-  z-index: 1;
+  z-index: 200;
+  margin-top: 0.4rem;
 
   a.current,
   a:hover {

--- a/fec_eregs/static/regulations/css/scss/module/_custom.scss
+++ b/fec_eregs/static/regulations/css/scss/module/_custom.scss
@@ -377,7 +377,7 @@ html, body, .landing-content, .search-panel {
   .supplement-section section:before,
   .footnotes li:before {
       height: $mainhead_small_height;
-      margin: -1 * $mainhead_small_height 0 0;
+      margin: -1 * $mainhead_height 0 0;
   }
 
   .reg-section .level-1 li,
@@ -397,3 +397,47 @@ div.footer-disclaimer {
     font-family: $sans-serif;
   }
 }
+
+
+//Overriding some styled above for mobile and responsive breakpoints
+
+#site-header {
+  position: static;
+}
+
+#menu, .toc-head  {
+   top: 179px;
+  }
+  .reg-section:before {
+     margin: -314px 0 0;
+  }
+
+@media only screen and ( min-width: 790px ) and ( max-width: 997px ) {
+  #menu, .toc-head  {
+   top: 229px;
+  }
+  .reg-section:before {
+     margin: -2 * $mainhead_height + 40 0 0;
+  }
+
+}
+
+@media only screen and ( min-width: 721px ) and ( max-width: 789px ) {
+  #menu, .toc-head {
+   top: 269px;
+  }
+   .reg-section:before {
+     margin: -2 * $mainhead_height + 80 0 0;
+  }
+
+}
+
+@media only screen and ( max-width: 720px ) {
+  #menu, .toc-head  {
+   top: 83px
+  }
+  .reg-section:before {
+     margin: -179px 0 0;
+  }
+}
+

--- a/tasks.py
+++ b/tasks.py
@@ -60,7 +60,7 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'feature/eregs-639-mvp-ux'),
+    ('dev', lambda _, branch: branch == 'develop'),
 )
 
 

--- a/tasks.py
+++ b/tasks.py
@@ -60,7 +60,7 @@ def _detect_space(repo, branch=None, yes=False):
 DEPLOY_RULES = (
     ('prod', _detect_prod),
     ('stage', lambda _, branch: branch.startswith('release')),
-    ('dev', lambda _, branch: branch == 'develop'),
+    ('dev', lambda _, branch: branch == 'feature/eregs-639-mvp-ux'),
 )
 
 


### PR DESCRIPTION
## Summary
- Restore TOC toggle so Mobile users can access obscured content (see GIF below)
- Remove unused help icons in help-sidebar (this change is on master branch of regulations-site)
- Add link to search box (Eregs home) in help menu

- Resolves #639
Related issue: #533

Related PR:
A PR to regulations-site's master branch supports this PR:
https://github.com/fecgov/regulations-site/pull/2 
### Required reviewers

@pkfec and possibly @JonellaCulmer if we can push it to Dev

## Impacted areas of the application

modified:   fec_eregs/static/regulations/css/scss/module/_custom.scss
modified:   https://github.com/fecgov/regulations-site/blob/master/regulations/templates/regulations/generic_help.html

## Screenshots

###  Mobile TOC Toggle to show obscured content:
![eregs_mobile-toggle](https://user-images.githubusercontent.com/5572856/147776181-9f0251b6-7182-4d04-af73-cba7b83aca64.gif)

<hr>

## Related PRs

A PR to regulations-site's master branch supports this PR:
https://github.com/fecgov/regulations-site/pull/2 


## How to test

- checkout branch and run ` python manage.py compile_frontend`
- Run Eregs locally as you normally would
- See that TOC toggle button is now available
- Test in Mobile view to ensure users can now hide TOC to access content below
- Confirm that the only icons in the help sidebar are the `open/close arrows` for the TOC toggle
- The new `Search regulations` link in help-sidebar wont work locally because in production, the relative  URL is in the context of fec.gov, not localhost. But you can see that [fec.gov/regulations](https://www.fec.gov/regulations) goes to the right place.
