### PR TITLE
bump django to v3.2.10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # regulations-core
-django==3.1.14
+django==3.2.10
 cached_property==1.3.1
 django-mptt==0.13.4
 anyjson==0.3.3


### PR DESCRIPTION
## Summary (required)
Django version in requirements.txt file is incorrect. It should be v3.2.10. 

Django on fec-eregs repo was updated recently to lts version 3.2.10. See [PR](https://github.com/fecgov/fec-eregs/pull/647) for more details.


- Bump Django to lts v3.2.10 in requirements.txt

### Required reviewers

One developer

## Impacted areas of the application

Legal Resources/ Regulations


## How to test

- See `How to test` in  PR#https://github.com/fecgov/fec-eregs/pull/647. 

