### PR TITLE
upgrade celery and related packages

### DIFF
--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -11,7 +11,7 @@ billiard==3.5.0.3
 boto3==1.5.13
 botocore==1.8.50
 cached-property==1.3.1
-celery==4.1.0
+celery==5.2.3
 certifi==2018.1.18
 cfenv==0.5.3
 cffi==1.12
@@ -42,7 +42,7 @@ humanfriendly==4.9
 idna==2.6
 inflection==0.3.1
 invoke==0.22.0
-ipdb==0.10.3
+ipdb==0.13.2
 ipython==6.2.1
 ipython-genutils==0.2.0
 jedi==0.11.1

--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -1,13 +1,13 @@
 # only tested with Python 3.6.1--recommend using that version until
 # further notice.
 
-amqp==2.2.2
+amqp==5.0.9
 anyjson==0.3.3
 appnope==0.1.0
 asn1crypto==0.24.0
 attrs==17.4.0
 bandit==1.4.0
-billiard==3.5.0.3
+billiard==3.6.4.0
 boto3==1.5.13
 botocore==1.8.50
 cached-property==1.3.1
@@ -16,13 +16,13 @@ certifi==2018.1.18
 cfenv==0.5.3
 cffi==1.12
 chardet==3.0.4
-click==6.7
+click==8.0.3
 coloredlogs==9.0
 cryptography==3.3.2
 decorator==4.2.1
 dj-database-url==0.4.2
 django==3.2.10
-django-click==2.0.0
+django-click==2.3.0
 django-haystack==3.1.1
 django-js-asset==1.0.0
 django-mptt==0.13.4
@@ -49,7 +49,7 @@ jedi==0.11.1
 jmespath==0.9.3
 json-delta==2.0
 jsonschema==2.5.1
-kombu==4.1.0
+kombu==5.2.3
 lxml==4.6.5
 marshmallow==2.19.2
 networkx==2.1
@@ -69,7 +69,7 @@ pyOpenSSL==17.5.0
 pyparsing==2.2.1
 python-constraint==1.3.1
 python-dateutil==2.7.3
-pytz==2018.3
+pytz==2021.3
 PyYAML==5.4
 redis==3.1.0
 # regparser
@@ -94,7 +94,7 @@ sqlparse==0.4.2
 stevedore==1.28.0
 traitlets==4.3.2
 urllib3==1.26.7
-vine==1.1.4
+vine==5.0.0
 wcwidth==0.1.7
 webargs==5.5.3
 whitenoise==3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ futures==3.1.1
 requests==2.26.0
 urllib3==1.26.6 # pin for compatibility with requests
 boto3==1.5.13
-celery==4.1.0
+celery==5.2.3
 requests-toolbelt==0.8.0
 
 


### PR DESCRIPTION
## Summary (required)

Upgrade celery package to the latest and parser compatible version.

- Resolves #655 

(Include a summary of proposed changes and connect issue below)

- upgrade celery to version 5.2.3 in requirements.txt and requirements-parsing.txt


### Required reviewers

Two developers must


## How to test

Terminal 1 (for eregs): 
-  git checkout feature/upgrade-celery
- pyenv virtualenv venv-eregs
- pyenv activate venv-eregs
- pip install -r requirements.txt
- rm -rf node_modules
- npm i
- npm run build
- dropdb eregs-db
- createdb eregs-db
- python manage.py migrate
- npm install -g grunt-cli (In case you run into **No such file or directory: 'grunt': 'grunt'** error)
- python manage.py compile_frontend
- python manage.py runserver
- copy and paste URL in a browser : http://localhost:8000/ 

Terminal 2 (for parser):
- pyenv virtualenv venv-parser
- pyenv activate venv-parser
- pip install -r requirements-parsing.txt
- python load_regs/load_fec_regs.py local (2021 regulations will be parsed locally and uploaded to local API)


All 45 regulations should appear on the browser:http://localhost:8000/

**Screenshots:**
<img width="1386" alt="Screen Shot 2022-02-01 at 7 55 20 PM" src="https://user-images.githubusercontent.com/11650355/152076495-ebfdaeb1-b06f-4a3f-8a32-128a29ae73b7.png">

<img width="1413" alt="Screen Shot 2022-02-01 at 7 56 26 PM" src="https://user-images.githubusercontent.com/11650355/152076496-7886a2d3-c46e-4cf4-b102-d337dfc9e184.png">



