### PR TITLE
upgrade eregs parsing requirements

### DIFF
--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -1,11 +1,8 @@
-# only tested with Python 3.6.1--recommend using that version until
-# further notice.
-
 amqp==5.0.9
 anyjson==0.3.3
 appnope==0.1.0
 asn1crypto==0.24.0
-attrs==17.4.0
+attrs==18.2.0
 bandit==1.4.0
 billiard==3.6.4.0
 boto3==1.5.13
@@ -43,7 +40,7 @@ idna==2.6
 inflection==0.3.1
 invoke==0.22.0
 ipdb==0.13.2
-ipython==6.2.1
+ipython==7.16.3
 ipython-genutils==0.2.0
 jedi==0.11.1
 jmespath==0.9.3
@@ -59,7 +56,7 @@ parso==0.1.1
 pbr==4.0.0
 pexpect==4.4.0
 pickleshare==0.7.4
-prompt-toolkit==1.0.15
+prompt-toolkit==3.0.28
 psycopg2==2.7.3.2
 ptyprocess==0.5.2
 pycparser==2.18
@@ -73,13 +70,13 @@ pytz==2021.3
 PyYAML==5.4
 redis==3.1.0
 # regparser
--e git+https://github.com/fecgov/regulations-parser.git@upgrade-django-v3.2.12-parser#egg=regparser
+-e git+https://github.com/fecgov/regulations-parser.git@master#egg=regparser
 
 # regsite
--e git+git://github.com/fecgov/regulations-site@upgrade-django-v3.2.12-site#egg=regulations
+-e git+git://github.com/fecgov/regulations-site@master#egg=regulations
 
 # regcore
--e git+git://github.com/fecgov/regulations-core@upgrade-django-v3.2.12-core#egg=regcore
+-e git+git://github.com/fecgov/regulations-core@master#egg=regcore
 requests==2.25.1
 requests-cache==0.6.3
 requests-toolbelt==0.8.0

--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -21,7 +21,7 @@ coloredlogs==9.0
 cryptography==3.3.2
 decorator==4.2.1
 dj-database-url==0.4.2
-django==3.2.10
+django==3.2.12
 django-click==2.3.0
 django-haystack==3.1.1
 django-js-asset==1.0.0
@@ -34,7 +34,7 @@ enum34==1.1.6
 furl==1.0.1
 futures==3.1.1
 gitdb2==2.0.3
-GitPython==2.1.8
+GitPython==3.1.27
 gevent==1.4.0
 greenlet==0.4.16 # pinned to fix build problem (parent is gevent)
 gunicorn==19.10.0
@@ -73,15 +73,15 @@ pytz==2021.3
 PyYAML==5.4
 redis==3.1.0
 # regparser
--e git+https://github.com/fecgov/regulations-parser.git@master#egg=regparser
+-e git+https://github.com/fecgov/regulations-parser.git@upgrade-django-v3.2.12-parser#egg=regparser
 
 # regsite
--e git+git://github.com/fecgov/regulations-site@master#egg=regulations
+-e git+git://github.com/fecgov/regulations-site@upgrade-django-v3.2.12-site#egg=regulations
 
 # regcore
--e git+git://github.com/fecgov/regulations-core@master#egg=regcore
+-e git+git://github.com/fecgov/regulations-core@upgrade-django-v3.2.12-core#egg=regcore
 requests==2.25.1
-requests-cache==0.4.13
+requests-cache==0.6.3
 requests-toolbelt==0.8.0
 roman==2.0.0
 rq==1.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,11 +34,11 @@ greenlet==0.4.16 # pinned to fix build problem (parent gevent)
 -e eregs_extensions/
 
 # regparser
--e git+https://github.com/fecgov/regulations-parser.git@upgrade-django-v3.2.12-parser#egg=regparser
+-e git+https://github.com/fecgov/regulations-parser.git@master#egg=regparser
 
 # regsite
--e git+git://github.com/fecgov/regulations-site@upgrade-django-v3.2.12-site#egg=regulations
+-e git+git://github.com/fecgov/regulations-site@master#egg=regulations
 
 # regcore
--e git+git://github.com/fecgov/regulations-core@upgrade-django-v3.2.12-core#egg=regcore
+-e git+git://github.com/fecgov/regulations-core@master#egg=regcore
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # regulations-core
-django==3.2.10
+django==3.2.12
 cached_property==1.3.1
 django-mptt==0.13.4
 anyjson==0.3.3
@@ -27,18 +27,18 @@ dj-database-url==0.4.2
 gunicorn==19.10.0
 whitenoise==3.3.1
 invoke==0.22.0
-GitPython==2.1.15
+GitPython==3.1.27
 gevent==1.4.0
 greenlet==0.4.16 # pinned to fix build problem (parent gevent)
 
 -e eregs_extensions/
 
 # regparser
--e git+https://github.com/fecgov/regulations-parser.git@master#egg=regparser
+-e git+https://github.com/fecgov/regulations-parser.git@upgrade-django-v3.2.12-parser#egg=regparser
 
 # regsite
--e git+git://github.com/fecgov/regulations-site@master#egg=regulations
+-e git+git://github.com/fecgov/regulations-site@upgrade-django-v3.2.12-site#egg=regulations
 
 # regcore
--e git+git://github.com/fecgov/regulations-core@master#egg=regcore
+-e git+git://github.com/fecgov/regulations-core@upgrade-django-v3.2.12-core#egg=regcore
 


### PR DESCRIPTION
## Summary (required)

- Resolves #https://github.com/fecgov/fec-eregs/issues/661

upgrade python packages in requirements-parsing.txt:
- ipython
- gitpython
- django
- attrs
- requests-cache

### Required reviewers

Two developers must

## Impacted areas of the application

- Eregs parser  

## Screenshots
**Before:** 
snyk test --file=requirements-parsing.txt   --package-manager=pip on `develop`  branch:
<img width="1418" alt="Screen Shot 2022-02-28 at 9 29 33 PM" src="https://user-images.githubusercontent.com/11650355/156093278-a27327b7-c361-47ba-9bbc-d46721ef3088.png">


**After:** 
snyk test --file=requirements-parsing.txt   --package-manager=pip on `feature/upgrade-eregs-pkgs-feb`  branch:
<img width="1418" alt="Screen Shot 2022-02-28 at 9 21 21 PM" src="https://user-images.githubusercontent.com/11650355/156092542-d4f73456-1ae8-4a7a-a670-5a0057ce0072.png">


## How to test
- git checkout feature/upgrade-eregs-pkgs-feb

## Terminal - 1
-  pyenv virtualenv 3.7.12 venv-eregs-3712
- pyenv activate venv-eregs-3712
- pip install -r requirements.txt
- rm -rf node_modules
- npm i
- npm run build
- dropdb eregs-db (Database name in local_settings.py)
- createdb eregs-db
- python manage.py migrate
- python manage.py compile_frontend
- python manage.py runserver

## Terminal - 2
- pyenv virtualenv 3.7.12 venv-parser-3712
- pyenv activate venv-eregs-3712
- pip install -r requirements-parsing.txt
- python load_regs/load_fec_regs.py local (45 eRegs parse OK)
- snyk test --file=requirements-parsing.txt   --package-manager=pip (django, requests-cache, ipython, gitpython are not vulnerable pkg. Only networkx pkg is vulnerable)

