### PR TITLE
678-update unauthenticated git protocols

### DIFF
--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -73,10 +73,10 @@ redis==3.1.0
 -e git+https://github.com/fecgov/regulations-parser.git@master#egg=regparser
 
 # regsite
--e git+git://github.com/fecgov/regulations-site@master#egg=regulations
+-e git+https://github.com/fecgov/regulations-site@master#egg=regulations
 
 # regcore
--e git+git://github.com/fecgov/regulations-core@master#egg=regcore
+-e git+https://github.com/fecgov/regulations-core@master#egg=regcore
 requests==2.25.1
 requests-cache==0.6.3
 requests-toolbelt==0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -37,8 +37,8 @@ greenlet==0.4.16 # pinned to fix build problem (parent gevent)
 -e git+https://github.com/fecgov/regulations-parser.git@master#egg=regparser
 
 # regsite
--e git+git://github.com/fecgov/regulations-site@master#egg=regulations
+-e git+https://github.com/fecgov/regulations-site@master#egg=regulations
 
 # regcore
--e git+git://github.com/fecgov/regulations-core@master#egg=regcore
+-e git+https://github.com/fecgov/regulations-core@master#egg=regcore
 


### PR DESCRIPTION
## Summary

- Resolves #678 

Updates 4 instances of the deprecated git protocol git+git:// to https:// which should fix the recent circleci [build failures.](https://app.circleci.com/pipelines/github/fecgov/fec-eregs?filter=all) Also, opened [another issue](https://github.com/fecgov/fec-eregs/issues/680) to fully remove/research all of the additional instances of the deprecated protocols. 

### Required reviewers

1-2 devs

## Impacted areas of the application
Should fix the failing [builds](https://app.circleci.com/pipelines/github/fecgov/fec-eregs?filter=all)


## How to test
- gh pr checkout feature/678-update-unauthenticated-git-protocols

### Terminal - 1
-  pyenv virtualenv 3.7.12 venv-eregs-3712
- pyenv activate venv-eregs-3712
- *[you may need to run:](https://github.com/fecgov/fec-eregs/wiki/Parse-regulations-on-local) 
echo "API_BASE = 'http://localhost:8000/api/' " >> local_settings.py 
and add to local_settings.py: 
DATABASES = {
      'default': {
        'ENGINE': 'django.db.backends.postgresql_psycopg2',
        'NAME': 'eregs_local',
        'HOST': '127.0.0.1',
        'PORT': '5432',
      }
    }
- pip install -r requirements.txt
- rm -rf node_modules
- npm i
- npm run build
- dropdb eregs-local (Database name in local_settings.py)
- createdb eregs-local
- python manage.py migrate
- python manage.py compile_frontend
- python manage.py runserver

### Terminal - 2
- pyenv virtualenv 3.7.12 venv-parser-3712
- pyenv activate venv-eregs-3712
- pip install -r requirements-parsing.txt
- python load_regs/load_fec_regs.py local (takes about 15 min)

http://localhost:8000/api/