### PR TITLE
672 & 681-upgrade django (3.2.13) and networkx (2.6.3)

### DIFF
--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -18,7 +18,7 @@ coloredlogs==9.0
 cryptography==3.3.2
 decorator==4.2.1
 dj-database-url==0.4.2
-django==3.2.12
+django==3.2.13
 django-click==2.3.0
 django-haystack==3.1.1
 django-js-asset==1.0.0
@@ -49,7 +49,7 @@ jsonschema==2.5.1
 kombu==5.2.3
 lxml==4.6.5
 marshmallow==2.19.2
-networkx==2.1
+networkx==2.6.3
 newrelic==2.100.0.84
 orderedmultidict==0.7.11
 parso==0.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # regulations-core
-django==3.2.12
+django==3.2.13
 cached_property==1.3.1
 django-mptt==0.13.4
 anyjson==0.3.3


### PR DESCRIPTION
## Summary (required)

- Resolves #672 
- Resolves #681 

(Include a summary of proposed changes and connect issue below)
Networkx 2.6.3 upgrade highlights:
Replace deprecated method .node with .nodes in regulation-parser. Also, removes low numpy snyk issues from 2.6
(also updated gitdb and smmap version bc I was getting circular dependency issue when I pulled the parser repo) 

Upgraded django to 3.2.13 in regulations-parser, regulations-site, and regulations-core. 

### Required reviewers

2-3 devs

## Impacted areas of the application

General components of the application that this PR will affect:

- Legal Resources/ Regulations

## Related PRs
Regulations-Parser PR:
https://github.com/fecgov/regulations-parser/pull/4
Regulations-Core PR:
https://github.com/fecgov/regulations-core/pull/4
Regulations-Site PR: 
https://github.com/fecgov/regulations-site/pull/4

## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)

**Terminal#1:** 
1. create python 3.7.12 virtualenv for fec-eregs: run `pyenv virtualenv 3.7.12 venv-eregs-3712` 
2. `pyenv activate venv-eregs-3712`
3. checkout branch
4. open requirements.txt and change the lines for the parser, site, and core to point to my PR's (lines 36-44):

> \# regparser
> -e git+https://github.com/fecgov/regulations-parser.git@upgrade-networkx-and-django#egg=regparser

> \# regsite
> -e git+https://github.com/fecgov/regulations-site@upgrade-django-3.2.13#egg=regulations

> \# regcore
-e git+https://github.com/fecgov/regulations-core@upgrade-django-3.2.13#egg=regcore
6. open requirements-parsing.txt and do the same thing (lines 72-79):

> \# regparser
> -e git+https://github.com/fecgov/regulations-parser.git@upgrade-networkx-and-django#egg=regparser

> \# regsite
> -e git+https://github.com/fecgov/regulations-site@upgrade-django-3.2.13#egg=regulations

> \# regcore
-e git+https://github.com/fecgov/regulations-core@upgrade-django-3.2.13#egg=regcore

7. install the requirements.txt: run `pip install -r requirements.txt` (make sure you're using version 22.0.4  of pip or upgrade according to warning and re-run) (Also it will ask you if you want to use the old version or switch to my branches and you should type `s`)
8. remove node_modules: run `rm -rf node_modules`
10. run `npm i` (you can make sure you're running the proper version with `nvm install 14.15.5`)
11. run  `npm run build`
12. run `dropdb eregs-db` if the eregs database already exist.
13. run `createdb eregs-db` (same name as defined in local_settings.py) 
 _create a new local_settings.py with the following configuration if one doesn't exist:_
```
API_BASE = 'http://localhost:8000/api/'
DATABASES = {
  'default': {
    'ENGINE': 'django.db.backends.postgresql_psycopg2',
    'NAME': 'eregs-db',
    'HOST': '127.0.0.1',
    'PORT': '5432',
  }
}
```
14. run `python manage.py migrate`
15. run `python manage.py compile_frontend` (if you don't already have a compiled folder then `mkdir compiled`) 
16. run `python manage.py runserver` (leave this running)

**Terminal#2:**
1.  create python 3.7.12 virtualenv for parser: run `pyenv virtualenv 3.7.12 venv-parser-3712` 
2. `pyenv activate venv-parser-3712`
3. install parser requirements:  run `pip install -r requirements-parsing.txt` (same as above with pip version 22.0.4 and nvm version v.14.15.5) NOTE: You will see a warning about networkx being yanked that's ok
4. run `snyk test --file=requirements-parsing.txt --package-manager=pip`   (you should not see the networkx issues or django issues anymore)
5. parse 2021 regs on to local db: run `python load_regs/load_fec_regs.py local`

This is my first time with e-regs, so please let me know if there's improvements I can make! Thank you very much!
