### PR TITLE
698-Upgrade lxml

### DIFF
--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -46,7 +46,7 @@ jmespath==0.9.3
 json-delta==2.0
 jsonschema==2.5.1
 kombu==5.2.3
-lxml==4.6.5
+lxml==4.9.1
 marshmallow==2.19.2
 networkx==2.6.3
 newrelic==2.100.0.84


### PR DESCRIPTION
## Summary (required)

- Resolves #698 
- Update lxml package to remove NULL Pointer Dereference vulnerability

### Required reviewers

1-2 devs


## Related PRs
Regulations-Parser PR:
https://github.com/fecgov/regulations-parser/pull/6

## Impacted areas of the application

-  Affected versions of this package are vulnerable to NULL Pointer Dereference in the iterwalk() function (used by canonicalize) that can be triggered by malicious input.

NOTE: This only applies when lxml is used together with libxml2 2.9.10 through 2.9.14.

## How to test

- check out this branch

**Terminal#1:** 
1. create python 3.8.12 virtualenv for fec-eregs: run `pyenv virtualenv 3.8.12 venv-eregs-3812` 
2. `pyenv activate venv-eregs-3812`
3.  open requirements.txt and change the lines for the parser, site, and core to point to my PR's (lines 36-44):

> \# regparser
> -e git+https://github.com/fecgov/regulations-parser.git@upgrade-django-4.9.1#egg=regparser

4. open requirements-parsing.txt and do the same thing (lines 72-79):

> \# regparser
> -e git+https://github.com/fecgov/regulations-parser.git@upgrade-lxml-4.9.1#egg=regparser

6. install the requirements.txt: run `pip install -r requirements.txt` 
7. install the requirements.txt: run `pip install -r requirements-parsing.txt` 
8. optional `rm -rf node_modules`
9. run `npm i` ( make sure you're running the proper version with `nvm install 14.15.5`)
10. run  `npm run build`
11. run `dropdb eregs-db` if the eregs database already exist.
12. run `createdb eregs-db` (same name as defined in local_settings.py) 
 _create a new local_settings.py with the following configuration if one doesn't exist:_
```
API_BASE = 'http://localhost:8000/api/'
DATABASES = {
  'default': {
    'ENGINE': 'django.db.backends.postgresql_psycopg2',
    'NAME': 'eregs-db',
    'HOST': '127.0.0.1',
    'PORT': '5432',
  }
}
```
13. run `python manage.py migrate`
14. run `python manage.py compile_frontend` (if you don't already have a compiled folder then `mkdir compiled`) 
15. run `python manage.py runserver` (leave this running)

**Terminal#2:**
1.  create python 3.8.12 virtualenv for parser: run `pyenv virtualenv 3.8.12 venv-parser-3812` 
2. `pyenv activate venv-parser-3812`
4. install parser requirements:  run `pip install -r requirements-parsing.txt` (same as above with pip version 22.0.4 and nvm version v.14.15.5)
5. run `snyk test --file=requirements-parsing.txt --package-manager=pip`   (you should not see the  issue anymore)
6. parse 2022 regs on to local db: run `python load_regs/load_fec_regs.py local`
