### PR TITLE
703 Django Vulnerability Redirected File Download RDI

### DIFF
--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -17,7 +17,7 @@ coloredlogs==9.0
 cryptography==3.3.2
 decorator==4.2.1
 dj-database-url==0.4.2
-django==3.2.14
+django==3.2.15
 django-click==2.3.0
 django-haystack==3.1.1
 django-js-asset==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # regulations-core
-django==3.2.14
+django==3.2.15
 cached_property==1.3.1
 django-mptt==0.13.4
 jsonschema==2.5.1


### PR DESCRIPTION
## Summary

- Resolves #703 

### Required reviewers

1-2 who can verify SNYK alerts have been satisfied (feel free to remove yourself)

## Impacted areas of the application

It's Django, so potentially everything. But it's [only a patch release](https://docs.djangoproject.com/en/4.0/releases/3.2.15/) so likely little change.

## Screenshots

No visual changes

## Related PRs

repo | branch | PR
------ | ------ | ------
fec-eregs | feature/703-django-vulnerability | #705 (self)
regulations-core | django-to-3.2.15 | [core #6](https://github.com/fecgov/regulations-core/pull/6)
regulations-parser | django-3.2.14-=>-3.2.15 | [parser #7](https://github.com/fecgov/regulations-parser/pull/7)
regulations-site | upgrade-django-3.2.15 | [site #6](https://github.com/fecgov/regulations-site/pull/6)

## How to test

First, we need to update the parser to allow 3.2.15 instead of strictly pinning to 3.2.14.

- pull the branch
- `pip install -r requirements.txt` ?
- `snyk test --file=requirements.txt`
- `snyk test --file=requirements-parsing.txt`
- make sure this vulnerability isn't listed
- **How do we check that eregs and its parsing is still working?**
- let the rest of us know of a better way to test it?
