### PR TITLE
upgrade python to 3.9.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       # https://circleci.com/developer/images
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
-      - image: cimg/python:3.8
+      - image: cimg/python:3.9
         environment:
           TZ: America/New_York
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Running `npm run build` will compile both the JS and SCSS files (generating `/st
 It's also important to keep in mind that the `compile_frontend` management command will compile the base regulations styles located at `fec_eregs/static/regulations/*`.
 
 ## Local Development
-This application requires Python 3.8.X
+This application requires Python 3.9.X
 
 Use pip and npm to download the required libraries:
 

--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -31,8 +31,7 @@ furl==1.0.1
 futures==3.1.1
 gitdb2==2.0.3
 GitPython==3.1.27
-gevent==1.4.0
-greenlet==0.4.16 # pinned to fix build problem (parent is gevent)
+gevent==21.12.0
 gunicorn==19.10.0
 humanfriendly==4.9
 idna==2.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,8 +27,7 @@ gunicorn==19.10.0
 whitenoise==3.3.1
 invoke==0.22.0
 GitPython==3.1.27
-gevent==1.4.0
-greenlet==0.4.16 # pinned to fix build problem (parent gevent)
+gevent==21.12.0
 
 -e eregs_extensions/
 

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.8.x
+python-3.9.x


### PR DESCRIPTION
## Summary (required)

- Resolves #709 

Upgrades python version to 3.9 to stay consistent with CMS and API. We needed to upgrade CMS due to vulnerability within pyJWT https://github.com/fecgov/fec-cms/pull/5401

### Required reviewers

1-2 devs

## Related PRs
https://github.com/fecgov/fec-cms/pull/5401
https://github.com/fecgov/openFEC/pull/5233

## How to test
- git checkout feature/709-upgrade-python

## Terminal - 1
- pyenv virtualenv 3.9.13 venv-eregs-3913
- pyenv activate venv-eregs-3913
-open requirements.txt and change the lines for the parser, site, and core to point to my PR's (lines 36-44):

> \# regparser
> -e git+https://github.com/fecgov/regulations-parser.git@upgrade-python#egg=regparser

> \# regcore
-e git+https://github.com/fecgov/regulations-core@upgrade-python#egg=regcore
- open requirements-parsing.txt and do the same thing (lines 72-79):

> \# regparser
> -e git+https://github.com/fecgov/regulations-parser.git@upgrade-python#egg=regparser

> \# regcore
-e git+https://github.com/fecgov/regulations-core@upgrade-python#egg=regcore


- pip install -r requirements.txt
- rm -rf node_modules
- npm i
- npm run build
- dropdb eregs-db (Database name in local_settings.py)
- createdb eregs-db
- python manage.py migrate
- python manage.py compile_frontend
- python manage.py runserver (leave this running)

## Terminal - 2
- pyenv virtualenv 3.9.13 venv-parser-3913
- pyenv activate venv-parser-3913
- pip install -r requirements-parsing.txt
- python load_regs/load_fec_regs.py local 
**Note:** I will update python version in [eregs wiki](https://github.com/fecgov/fec-eregs/wiki/Parse-regulations-on-local) after this PR gets merged.
