### PR TITLE
upgrade django to 3.2.16

### DIFF
--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -17,7 +17,7 @@ coloredlogs==9.0
 cryptography==3.3.2
 decorator==4.2.1
 dj-database-url==0.4.2
-django==3.2.15
+django==3.2.16
 django-click==2.3.0
 django-haystack==3.1.1
 django-js-asset==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # regulations-core
-django==3.2.15
+django==3.2.16
 cached_property==1.3.1
 django-mptt==0.13.4
 jsonschema==2.5.1


### PR DESCRIPTION
## Summary 
Upgrade Django to patch version 3.2.16

- Resolves #718 #715  

 - Upgrade django in fec-eregs/requirements.txt & requirements-parsing.txt
 - Upgrade django in dependency projects: 
       - [regulation-core](https://github.com/fecgov/regulations-core/pull/9)
       - [regulation-parser](https://github.com/fecgov/regulations-parser/pull/11)
       - [regulation-site](https://github.com/fecgov/regulations-site/pull/7)

### Required reviewers

1-2 devs

## Related PRs
https://github.com/fecgov/regulations-core/pull/9
https://github.com/fecgov/regulations-parser/pull/11
https://github.com/fecgov/regulations-site/pull/7

## How to test

## Terminal - 1
- pyenv virtualenv 3.9.13 eregs-3913
- pyenv activate eregs-3913

- open requirements.txt and change the lines for the parser, site, and core to point to my PR(s):

```
# regparser
 -e git+https://github.com/fecgov/regulations-parser.git@feature/718-upgrade-django-parser#egg=regparser

# regsite
-e git+https://github.com/fecgov/regulations-site@feature/718-upgrade-django-site#egg=regulations

# regcore
-e git+https://github.com/fecgov/regulations-core@feature/718-upgrade-django-core#egg=regcore

```

- open requirements-parsing.txt and change the lines for the parser, site, and core to point to my PR(s) :

```
# regparser
-e git+https://github.com/fecgov/regulations-parser.git@feature/718-upgrade-django-parser#egg=regparser

# regsite
-e git+https://github.com/fecgov/regulations-site@feature/718-upgrade-django-site#egg=regulations

# regcore
-e git+https://github.com/fecgov/regulations-core@feature/718-upgrade-django-core#egg=regcore


```
- pip install -r requirements.txt
- rm -rf node_modules
- npm i
- npm run build
- dropdb eregs-db (Database name in local_settings.py)
- createdb eregs-db
- python manage.py migrate
- python manage.py compile_frontend
- python manage.py runserver (leave this running)

## Terminal - 2
- pyenv virtualenv 3.9.13 parser-3913
- pyenv activate parser-3913
- pip install -r requirements-parsing.txt
- python load_regs/load_fec_regs.py local 

All 45 regulations parsed successfully and appear on the local eregs server: http://localhost:8000/



