### PR TITLE
727-upgrade setuptools deps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ futures==3.1.1
 requests==2.26.0
 urllib3==1.26.6 # pin for compatibility with requests
 boto3==1.5.13
-celery==5.2.3
+celery==5.2.7
 requests-toolbelt==0.8.0
 
 
@@ -27,7 +27,7 @@ gunicorn==19.10.0
 whitenoise==3.3.1
 invoke==0.22.0
 GitPython==3.1.27
-gevent==21.12.0
+gevent==22.10.2
 
 -e eregs_extensions/
 


### PR DESCRIPTION
## Summary (required)

- Resolves #727 
We are still getting the setuptools snyk vulnerability because it's dependencies are in the requirements.txt file as well as the requirements-parsing file that was already upgraded. This should remove those alerts and keep us consistent between those files. 

### Required reviewers

1-2 devs

## Screenshots
Before:
<img width="1146" alt="Screen Shot 2022-12-28 at 2 54 26 PM" src="https://user-images.githubusercontent.com/66386084/209865420-61f3f767-ec6d-49ae-b776-a19142ebbe1d.png">
After:
<img width="1146" alt="Screen Shot 2022-12-28 at 2 43 34 PM" src="https://user-images.githubusercontent.com/66386084/209864321-bca469d5-7d5d-4f91-b5ca-d780811b00bf.png">


## How to test


Parser write 45 regulations to the local eregs API. It will take ~10 minutes to finish parsing 45 regulations 
`snyk test --file=requirements.txt --package-manager=pip` 

-  checkout branch
- Terminal 1:
    -  pyenv virtualenv venv-eregs
    - pip install -r requirements.txt
    - rm -rf node_modules
    - npm i
    - npm run build
    - dropdb eregs_db (change the db name based on what is given in local_settings.py)
    - createdb eregs_db
    - python manage.py migrate
    - python manage.py compile_frontend
    - python manage.py runserver (leave this running)
- Terminal 2:
   - pyenv virtualenv venv-parser
   - pip install -r requirements-parsing.txt
   - run : `snyk test --file=requirements.txt --package-manager=pip` 
   - python load_regs/load_fec_regs.py local
   - http://127.0.0.1:8000/ (2022 regulations will show here)

For more detailed instructions [follow the wiki](https://github.com/fecgov/fec-eregs/wiki/Parse-regulations-on-local) on how to setup/parse regulations on local environment