### PR TITLE
728-upgrade gitpython

### DIFF
--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -30,7 +30,7 @@ enum34==1.1.6
 furl==1.0.1
 futures==3.1.1
 gitdb2==2.0.3
-GitPython==3.1.27
+GitPython==3.1.30
 gevent==22.10.2
 gunicorn==19.10.0
 humanfriendly==4.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ dj-database-url==0.4.2
 gunicorn==19.10.0
 whitenoise==3.3.1
 invoke==0.22.0
-GitPython==3.1.27
+GitPython==3.1.30
 gevent==21.12.0
 
 -e eregs_extensions/


### PR DESCRIPTION
## Summary (required)

- Resolves #728 
GitPython is in maintenance mode. I did some research and as we use Gitpython for our releases it will be challenging to switch over to Pygit2 or Dulwich, but we will probably need to do it in the future. Currently, GitPython is most widely used and have releases/patches pretty fast.

### Required reviewers

1 dev

## Impacted areas of the application

General components of the application that this PR will affect:

-  Interaction with git libraries, automated release process

## How to test

(Include any information that may be helpful to the reviewer(s). This might include links to sample pages to test or any local environmental setup that is unusual such as environment variable (never credentials), API version to point to, etc)

- checkout and pull the latest `develop` branch
- run `snyk test --all-projects`. Shows vulnerability. 
- `gh pr checkout `
- run `pip install -r requirements.txt` 
- run `pip install -r requirements-parsing.txt` 
- run `snyk test --all-projects`
- ~run `pytest`~
- `python manage.py runserver`