### PR TITLE
upgrade django, cryptography, prompt-toolkit, and ipython

### DIFF
--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -14,10 +14,10 @@ cffi==1.15.0
 chardet==3.0.4
 click==8.0.3
 coloredlogs==9.0
-cryptography==3.3.2
+cryptography==39.0.1
 decorator==4.2.1
 dj-database-url==0.4.2
-django==3.2.16
+django==3.2.18
 django-click==2.3.0
 django-haystack==3.1.1
 django-js-asset==1.0.0
@@ -38,7 +38,7 @@ idna==2.6
 inflection==0.3.1
 invoke==0.22.0
 ipdb==0.13.2
-ipython==8.7.0
+ipython==8.10.0
 ipython-genutils==0.2.0
 jedi==0.18.2
 jmespath==0.9.3
@@ -54,7 +54,7 @@ parso==0.8.3
 pbr==4.0.0
 pexpect==4.4.0
 pickleshare==0.7.4
-prompt-toolkit==3.0.28
+prompt-toolkit==3.0.30
 psycopg2==2.9.1
 ptyprocess==0.5.2
 pycparser==2.18

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # regulations-core
-django==3.2.16
+django==3.2.18
 cached_property==1.3.1
 django-mptt==0.13.4
 jsonschema==2.5.1


### PR DESCRIPTION
## Summary (required)

- Resolves #744 and #747 

This ticket fixes the snyk vulnerbilities in requirements-parsing.txt and upgrades django in requirements.txt.

packages upgraded: 
- cryptography@3.3.2 to cryptography@39.0.1
- django@3.2.16 to django@3.2.18
- ipython@8.7.0 to ipython@8.10.0
- prompt-toolkit@3.0.28 to prompt-toolkit@3.0.30
 

### Required reviewers 2 developers 


## Impacted areas of the application

General components of the application that this PR will affect:

-  eregs and eregs parsing 

## Screenshots
Before:

requirements.txt: 
 
![image](https://user-images.githubusercontent.com/121631201/220675892-5ee7af14-a428-4b32-9f9e-b3435326d93e.png)

requirements-parsing.txt:
![image](https://user-images.githubusercontent.com/121631201/220676233-60210c24-3651-41c8-bc6d-47d75e9938bd.png)

After: 

requirements.txt: 
![image](https://user-images.githubusercontent.com/121631201/220676400-e74bd083-ed74-4b02-b4ef-d7c211d5b34e.png)

requirements-parsing.txt:
![image](https://user-images.githubusercontent.com/121631201/220676541-f84d045f-fc35-4ae8-8a69-6df00869cf62.png)


## Related PRs

Related PRs against other branches:

[reg-core PR ](https://github.com/fecgov/regulations-core/pull/10)
[reg-parser PR](https://github.com/fecgov/regulations-parser/pull/12)
[reg-site PR](https://github.com/fecgov/regulations-site/pull/9)

## How to test
1. Checkout this branch 
2.  Change regparser, regsite, and regcore to point to my branch in requirements.txt and requirements-parsing.txt 

-e git+https://github.com/fecgov/regulations-parser.git@update-requirements-parsing#egg=regparser

-e git+https://github.com/fecgov/regulations-site@update-requirements-parsing#egg=regulations

-e git+https://github.com/fecgov/regulations-core@update-requirements-parsing#egg=regcore

Terminal One: 
3. `pyenv virtualenv (your virtual environment)`
4. `pip install -r requirements.txt`
5. `snyk test --file=requirements.txt --package-manager=pip`
6. `rm -rf node_modules`
7. `npm i`
8. `npm run build`
9. `dropdb eregs_local`
10. `createdb eregs_local`
11. `python manage.py migrate`
12. `python manage.py compile_frontend`
13. `python manage.py runserver`

Terminal Two:
14. `pyenv virtualenv (your virtual environment)`
15. `pip install -r requirements-parsing.txt`
16. `snyk test --file=requirements-parsing.txt --package-manager=pip`
17. `python load_regs/load_fec_regs.py local`
18. Go to http://127.0.0.1:8000/ to view 45 regulations 

For more detailed instructions [follow the wiki](https://github.com/fecgov/fec-eregs/wiki/Parse-regulations-on-local) on how to setup/parse regulations on local environment

This will not pass circle build until other PRs are merged first. 

