### PR TITLE
update redis

### DIFF
--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -66,7 +66,7 @@ python-constraint==1.3.1
 python-dateutil==2.7.3
 pytz==2021.3
 PyYAML==5.4
-redis==3.1.0
+redis==4.5.4
 # regparser
 -e git+https://github.com/fecgov/regulations-parser.git@master#egg=regparser
 

--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -86,7 +86,7 @@ simplegeneric==0.8.1
 simplejson==3.13.2
 six==1.11.0
 smmap2==2.0.3
-sqlparse==0.4.2
+sqlparse==0.4.4
 stevedore==1.28.0
 traitlets==5.7.0
 urllib3==1.26.7


### PR DESCRIPTION
## Summary (required)

- Resolves #753 

This ticket fixes the snyk vulnerbilities in requirements-parsing.txt.

packages upgraded: 
- redis@3.1.0 to redis@4.5.4
- sqlparse@0.4.2 to sqlparse@0.4.4


### Required reviewers 1 developers 


## Impacted areas of the application

General components of the application that this PR will affect:

-  eregs and eregs parsing 

## Related PRs

Related PRs against other branches:

[reg-parser PR](https://github.com/fecgov/regulations-parser/pull/13)

## How to test
1. Checkout this branch 
2.  Change regparser to point to my branch in requirements.txt and requirements-parsing.txt 

-e git+https://github.com/fecgov/regulations-parser.git@upgrade-redis-to-v4#egg=regparser

Terminal One: 
3. `pyenv virtualenv (your virtual environment)`
4. `pip install -r requirements.txt`
5. `snyk test --file=requirements.txt --package-manager=pip`
6. `rm -rf node_modules`
7. `npm i`
8. `npm run build`
9. `dropdb eregs_local`
10. `createdb eregs_local`
11. `python manage.py migrate`
12. `python manage.py compile_frontend`
13. `python manage.py runserver`

Terminal Two:
14. `pyenv virtualenv (your virtual environment)`
15. `pip install -r requirements-parsing.txt`
16. `snyk test --file=requirements-parsing.txt --package-manager=pip`
17. `python load_regs/load_fec_regs.py local`
18. Go to http://127.0.0.1:8000/ to view 45 regulations 

For more detailed instructions [follow the wiki](https://github.com/fecgov/fec-eregs/wiki/Parse-regulations-on-local) on how to setup/parse regulations on local environment

This will not pass circle build until other PRs are merged first. 
