### PR TITLE
upgrade node 18.17.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ jobs:
             export NVM_DIR="$HOME/.nvm"
             [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
             [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-            nvm install v18.13.0
-            nvm use 18.13.0
-            nvm alias default 18.13.0
+            nvm install v18.17.1
+            nvm use 18.17.1
+            nvm alias default 18.17.1
             npm install -g grunt-cli
             npm install
             npm run build

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,8 +27,8 @@
         "lodash": "4.17.21"
       },
       "engines": {
-        "node": "18.13.0",
-        "npm": "8.19.3"
+        "node": "18.17.1",
+        "npm": "9.6.7"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "url": "https://github.com/fecgov/fec-eregs/issues"
   },
   "engines": {
-    "node": "18.13.0",
-    "npm": "8.19.3"
+    "node": "18.17.1",
+    "npm": "9.6.7"
   },
   "homepage": "https://github.com/fecgov/fec-eregs#readme"
 }


### PR DESCRIPTION
## Summary (required)

- Resolves #789 

Upgrades node to 18.17.1

### Required reviewers
1 dev


## Related PRs
**https://github.com/fecgov/regulations-site/pull/12**

## How to test

Checkout this branch

Terminal One:
2. pyenv virtualenv (your virtual environment)
3. change regulations site line in requirements.txt AND requirements-parsing.txt to
-e git+https://github.com/fecgov/regulations-site@upgrade-node-18.17.1#egg=regulations
5. pip install -r requirements.txt
6. rm -rf node_modules
7. npm i
8.  npm install -g grunt-cli
9. npm run build
10.  dropdb eregs_local
11. createdb eregs_local
12. python manage.py migrate
13. python manage.py compile_frontend
14. python manage.py runserver (leave running)

Terminal Two:
15. pyenv virtualenv (your virtual environment)
16. pip install -r requirements-parsing.txt
17. python load_regs/load_fec_regs.py local
18. Go to [http://127.0.0.1:8000/ to](http://127.0.0.1:8000/%C2%A0to) view 45 regulations

For more detailed instructions [follow the wiki](https://github.com/fecgov/fec-eregs/wiki/Parse-regulations-on-local) on how to setup/parse regulations on local environment

