### PR TITLE
797- upgrade django, urllib3, and cryptography

### DIFF
--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -14,10 +14,10 @@ cffi==1.15.0
 chardet==3.0.4
 click==8.0.3
 coloredlogs==9.0
-cryptography==41.0.3
+cryptography==41.0.5
 decorator==4.2.1
 dj-database-url==0.4.2
-django==3.2.21
+django==3.2.22
 django-click==2.3.0
 django-haystack==3.1.1
 django-js-asset==1.0.0
@@ -89,7 +89,7 @@ smmap2==2.0.3
 sqlparse==0.4.4
 stevedore==1.28.0
 traitlets==5.7.0
-urllib3==1.26.7
+urllib3==1.26.18
 vine==5.0.0
 wcwidth==0.1.7
 webargs==5.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # regulations-core
-django==3.2.21
+django==3.2.22
 cached_property==1.3.1
 django-mptt==0.13.4
 jsonschema==2.5.1
@@ -14,7 +14,7 @@ psycopg2==2.9.1
 enum34==1.1.6
 futures==3.1.1
 requests==2.31.0
-urllib3==1.26.6 # pin for compatibility with requests
+urllib3==1.26.18 # pin for compatibility with requests
 boto3==1.7.84
 celery==5.2.7
 requests-toolbelt==0.8.0


### PR DESCRIPTION
## Summary (required)

- Resolves #797 
Also resolves https://github.com/fecgov/fec-eregs/issues/804 https://github.com/fecgov/fec-eregs/issues/807

upgrades django, urllib3, and cryptography to remove snyk vulnerabilities

### Required reviewers
1-2 devs
  
## How to test
1. Checkout this branch 
2.  Change regparser, regulations, and regcore to point to my branch in requirements.txt and requirements-parsing.txt 

regparser
-e git+https://github.com/fecgov/regulations-parser.git@upgrade-django-3.2.22#egg=regparser
regsite
-e git+https://github.com/fecgov/regulations-site@upgrade-django-3.2.22#egg=regulations
regcore
-e git+https://github.com/fecgov/regulations-core@upgrade-django-3.2.22#egg=regcore

**Terminal One:** 
3. `pyenv virtualenv (your virtual environment)`
4. `pip install -r requirements.txt`
5. `snyk test --file=requirements.txt --package-manager=pip`
6. `rm -rf node_modules`
7. (may need to run `nvm install 18.17.1`)
8. `npm i && npm run build`
10. `dropdb eregs_local`
11. `createdb eregs_local`
12. `python manage.py migrate`
13. `python manage.py compile_frontend`
14. `python manage.py runserver` (leave running)

**Terminal Two:**
15. `pyenv virtualenv (your virtual environment)`
16. `pip install -r requirements-parsing.txt`
17. `snyk test --file=requirements-parsing.txt --package-manager=pip`
18. `python load_regs/load_fec_regs.py local`
19. Go to http://127.0.0.1:8000/ to view 45 regulations 

For more detailed instructions [follow the wiki](https://github.com/fecgov/fec-eregs/wiki/Parse-regulations-on-local) on how to setup/parse regulations on local environment

**NOTE: Merge other repo PRs first** 
