### PR TITLE
upgrade django and cryptography

### DIFF
--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -14,10 +14,10 @@ cffi==1.15.0
 chardet==3.0.4
 click==8.0.3
 coloredlogs==9.0
-cryptography==41.0.5
+cryptography==41.0.6
 decorator==4.2.1
 dj-database-url==0.4.2
-django==3.2.22
+django==3.2.23
 django-click==2.3.0
 django-haystack==3.1.1
 django-js-asset==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # regulations-core
-django==3.2.22
+django==3.2.23
 cached_property==1.3.1
 django-mptt==0.13.4
 jsonschema==2.5.1


### PR DESCRIPTION
## Summary (required)

- Resolves #812 
- and #814

This ticket upgrades django and cryptography to remove a security vulnerability. 

### Required reviewers - 1 developer

## Impacted areas of the application

-  eregs parsing

## Related PRs

1. [Regulations-Parser PR](https://github.com/fecgov/regulations-parser/pull/18)
2. [Regulations-Site PR ](https://github.com/fecgov/regulations-site/pull/15)
3. [Regulations-Core PR](https://github.com/fecgov/regulations-core/pull/16)


## How to test
1. Checkout this branch 
2.  Change regparser, regulations, and regcore to point to my branch in requirements.txt and requirements-parsing.txt 

regparser
-e git+https://github.com/fecgov/regulations-parser.git@upgrade-django-3.2.23#egg=regparser
regsite
-e git+https://github.com/fecgov/regulations-site@upgrade-django-3.2.23#egg=regulations
regcore
-e git+https://github.com/fecgov/regulations-core@upgrade-django-3.2.23#egg=regcore

**Terminal One:** 
3. `pyenv virtualenv (your virtual environment)`
4. `pip install -r requirements.txt`
5. `snyk test --file=requirements.txt --package-manager=pip`
6. `rm -rf node_modules`
7. `npm i`
8. `npm run build`
9. `dropdb eregs_local`
10. `createdb eregs_local`
11. `python manage.py migrate`
12. `python manage.py compile_frontend`
13. `python manage.py runserver` (leave running)

**Terminal Two:**
14. `pyenv virtualenv (your virtual environment)`
15. `pip install -r requirements-parsing.txt`
16. `snyk test --file=requirements-parsing.txt --package-manager=pip` NOTE: there is one security vulnerability in Cyptography that has no remediation yet. 
17. `python load_regs/load_fec_regs.py local`
18. Go to http://127.0.0.1:8000/  to view 45 regulations 

For more detailed instructions [follow the wiki](https://github.com/fecgov/fec-eregs/wiki/Parse-regulations-on-local) on how to setup/parse regulations on local environment

**NOTE: Merge other repo PRs first** 
