### PR TITLE
remove pyYAML and bandit from requirements-parsing.txt

### DIFF
--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -2,7 +2,6 @@ amqp==5.0.9
 appnope==0.1.0
 asn1crypto==0.24.0
 attrs==18.2.0
-bandit==1.4.0
 billiard==3.6.4.0
 boto3==1.7.84
 botocore==1.10.84
@@ -65,7 +64,6 @@ pyparsing==2.2.1
 python-constraint==1.3.1
 python-dateutil==2.7.3
 pytz==2021.3
-PyYAML==5.4
 redis==4.5.4
 # regparser
 -e git+https://github.com/fecgov/regulations-parser.git@master#egg=regparser


### PR DESCRIPTION
## Summary (required)

- Resolves #818 

This PR removes `pyYAML` and `bandit`.  I was never able to figure out why only my new M2 mac doesn't work with version 5.4. However, when looking into my issue I noticed that we don't directly use them . 

PyYAML, it is a package dependency for `bandit` which is a tool to find security vulnerabilities. Bandit is used in the tox file for reg site and core. So we do not use them for eregs or eregs parsing. Here is a link to an older [PR](https://github.com/fecgov/fec-eregs/pull/415) where we deleted `bandit` from requirements.txt.

I can also upgrade pyYAML to the latest version if we want to keep these packages in requirements-parsing.txt   

### Required reviewers 1 developer 

## How to test
1. Checkout this branch 
**Terminal One:** 
2. `pyenv virtualenv (your virtual environment)`
3. `pip install -r requirements.txt`
4. `rm -rf node_modules`
5. `npm i`
6. `npm run build`
7. `dropdb eregs_local`
8. `createdb eregs_local`
9. `python manage.py migrate`
10. `python manage.py compile_frontend`
11. `python manage.py runserver` (leave running)

**Terminal Two:**
13. `pyenv virtualenv (your virtual environment)`
14. (if using an old env) `pip uninstall bandit`
15. (if using an old env) `pip uninstall pyyaml`
16. `pip install -r requirements-parsing.txt`
17. `python load_regs/load_fec_regs.py local`
18. Go to http://127.0.0.1:8000/  to view 45 regulations 

For more detailed instructions [follow the wiki](https://github.com/fecgov/fec-eregs/wiki/Parse-regulations-on-local) on how to setup/parse regulations on local environment

