### PR TITLE
upgrade django and cryptography

### DIFF
--- a/fec_eregs/urls.py
+++ b/fec_eregs/urls.py
@@ -1,5 +1,5 @@
-from django.conf.urls import include, url
-
+from django.conf.urls import include
+from django.urls import re_path as url
 from regcore import urls as regcore_urls
 from regulations import urls as regsite_urls
 

--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -16,7 +16,7 @@ coloredlogs==9.0
 cryptography==42.0.5
 decorator==4.2.1
 dj-database-url==0.4.2
-django==4.2.10
+django==4.2.11
 django-click==2.3.0
 django-haystack==3.1.1
 django-js-asset==1.0.0

--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -13,10 +13,10 @@ cffi==1.15.0
 chardet==3.0.4
 click==8.0.3
 coloredlogs==9.0
-cryptography==42.0.2
+cryptography==42.0.5
 decorator==4.2.1
 dj-database-url==0.4.2
-django==3.2.23
+django==4.2.10
 django-click==2.3.0
 django-haystack==3.1.1
 django-js-asset==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # regulations-core
-django==4.2.10
+django==4.2.11
 cached_property==1.3.1
 django-mptt==0.13.4
 jsonschema==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # regulations-core
-django==3.2.23
+django==4.2.10
 cached_property==1.3.1
 django-mptt==0.13.4
 jsonschema==2.5.1


### PR DESCRIPTION
## Summary 

1. upgrade django and cryptography to resolve snyk vulnerabilities
2. Remove and replace deprecated url function with re_path


- Resolves #830 , #833


### Required reviewers

1 developers

## Impacted areas of the application

Eregs App and  Parser

## Related PRs

**Note:** Merge these pull requests before testing the current one.

I upgraded to the minor patch version of Django, v4.2.11, which was released on March 4th: 
https://github.com/fecgov/regulations-parser/pull/19
https://github.com/fecgov/regulations-site/pull/16
https://github.com/fecgov/regulations-core/pull/17

## How to test
1. Checkout this branch 
2. Change regparser, regulations, and regcore to point to my branch in requirements.txt and requirements-parsing.txt 

regparser
-e git+https://github.com/fecgov/regulations-parser.git@upgrade-django-4.2.10#egg=regparser
regsite
-e git+https://github.com/fecgov/regulations-site@upgrade-django-4.2.10#egg=regulations
regcore
-e git+https://github.com/fecgov/regulations-core@upgrade-django-4.2.10#egg=regcore

**Terminal One:** 
3. `pyenv virtualenv (your virtual environment)`
4. `pip install -r requirements.txt`
5. `rm -rf node_modules`
6. `npm i`
7. `npm run build`
8. `dropdb eregs_local`
9. `createdb eregs_local`
10. `python manage.py migrate`
11. `python manage.py compile_frontend`
12. `python manage.py runserver` (leave running)

**Terminal Two:**
13. `pyenv virtualenv (your virtual environment)`
14. `pip install -r requirements-parsing.txt`
15. `snyk test --file=requirements-parsing.txt --package-manager=pip` NOTE: Django, Cyptography are no longer flagged as vulnerable packages
16. `python load_regs/load_fec_regs.py local`
17. Go to http://127.0.0.1:8000/  to view 45 regulations 

For more detailed instructions [follow the wiki](https://github.com/fecgov/fec-eregs/wiki/Parse-regulations-on-local) on how to setup/parse regulations on local environment


