### PR TITLE
Feature/819 upgrade python v3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       # https://circleci.com/developer/images
       # use `-browsers` prefix for selenium tests, e.g. `<image_name>-browsers`
 
-      - image: cimg/python:3.9
+      - image: cimg/python:3.10
         environment:
           TZ: America/New_York
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Running `npm run build` will compile both the JS and SCSS files (generating `/st
 It's also important to keep in mind that the `compile_frontend` management command will compile the base regulations styles located at `fec_eregs/static/regulations/*`.
 
 ## Local Development
-This application requires Python 3.9.X
+This application requires Python 3.10.X
 
 Use pip and npm to download the required libraries:
 

--- a/requirements-parsing.txt
+++ b/requirements-parsing.txt
@@ -52,7 +52,7 @@ orderedmultidict==0.7.11
 parso==0.8.3
 pbr==4.0.0
 pexpect==4.4.0
-pickleshare==0.7.4
+pickleshare==0.7.5
 prompt-toolkit==3.0.30
 psycopg2==2.9.1
 ptyprocess==0.5.2

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9.x
+python-3.10.x


### PR DESCRIPTION
## Summary (required)

- Resolves #819 

This ticket upgrades python to version 3.10.13. 

### Required reviewers 1 - 2 developers 

## Impacted areas of the application

General components of the application that this PR will affect:

-  circleci pipeline
- parsing

## How to test
1. Checkout this branch 


**Terminal One:** 
2. `pyenv install 3.10.13`
3. `pyenv virtualenv 3.10.13 <new virtual environment>`
4. `pyenv activate <new virtual environment>`
5. `pip install -r requirements.txt`
6. `rm -rf node_modules`
7. `npm i`
8. `npm run build`
9. `dropdb eregs_local`
10. `createdb eregs_local`
11. `python manage.py migrate`
12. `python manage.py compile_frontend`
13. `python manage.py runserver` (leave running)

**Terminal Two:**
14. `pyenv virtualenv 3.10.13 <new parsing environment>`
15. `pyenv activate <new parsing environment>`
16. `pip install -r requirements-parsing.txt`
17. `python load_regs/load_fec_regs.py local`
18. Go to http://127.0.0.1:8000/  to view 45 regulations 

For more detailed instructions [follow the wiki](https://github.com/fecgov/fec-eregs/wiki/Parse-regulations-on-local) on how to setup/parse regulations on local environment

